### PR TITLE
Updated the version of the opensearch-connector dependency to 1.0.1

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -287,7 +287,7 @@
         <dependency>
             <groupId>com.utmstack</groupId>
             <artifactId>opensearch-connector</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.1</version>
         </dependency>
         <dependency>
             <groupId>jakarta.json</groupId>


### PR DESCRIPTION
It was required to update the opensearch-connector library to refactoring the method getFieldValues to return a Map based on a LinkedHashMap to keep the insertion order. The only change in the project was to update the version of the opensearch-connector dependency