### PR TITLE
Implementing a 404 response code for resource /api/elasticsearch/property/values

### DIFF
--- a/backend/src/main/java/com/park/utmstack/service/elasticsearch/ElasticsearchService.java
+++ b/backend/src/main/java/com/park/utmstack/service/elasticsearch/ElasticsearchService.java
@@ -1,5 +1,6 @@
 package com.park.utmstack.service.elasticsearch;
 
+import com.park.utmstack.util.exceptions.OpenSearchIndexNotFoundException;
 import com.utmstack.opensearch_connector.enums.IndexSortableProperty;
 import com.utmstack.opensearch_connector.enums.TermOrder;
 import com.utmstack.opensearch_connector.exceptions.OpenSearchException;
@@ -17,6 +18,7 @@ import com.park.utmstack.service.UtmSpaceNotificationControlService;
 import com.park.utmstack.service.application_events.ApplicationEventService;
 import com.park.utmstack.util.chart_builder.IndexPropertyType;
 import com.park.utmstack.util.exceptions.UtmElasticsearchException;
+import org.elasticsearch.index.IndexNotFoundException;
 import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch.cat.indices.IndicesRecord;
@@ -141,6 +143,10 @@ public class ElasticsearchService {
      */
     public List<IndexPropertyType> getIndexProperties(String indexPattern) {
         final String ctx = CLASSNAME + ".getIndexProperties";
+
+        if (!indexExist(indexPattern))
+            throw new OpenSearchIndexNotFoundException(ctx  + ": Index [" + indexPattern + "] not found");
+
         try {
             Map<String, String> properties = client.getClient().getIndexProperties(indexPattern);
             if (CollectionUtils.isEmpty(properties))

--- a/backend/src/main/java/com/park/utmstack/util/UtilResponse.java
+++ b/backend/src/main/java/com/park/utmstack/util/UtilResponse.java
@@ -31,5 +31,9 @@ public class UtilResponse {
     public static <T> ResponseEntity<T> buildPreconditionFailedResponse(String msg) {
         return buildErrorResponse(HttpStatus.PRECONDITION_FAILED, msg);
     }
+
+    public static <T> ResponseEntity<T> buildNotFoundResponse(String msg) {
+        return buildErrorResponse(HttpStatus.NOT_FOUND, msg);
+    }
 }
 

--- a/backend/src/main/java/com/park/utmstack/util/exceptions/OpenSearchIndexNotFoundException.java
+++ b/backend/src/main/java/com/park/utmstack/util/exceptions/OpenSearchIndexNotFoundException.java
@@ -1,0 +1,10 @@
+package com.park.utmstack.util.exceptions;
+
+public class OpenSearchIndexNotFoundException extends RuntimeException {
+    public OpenSearchIndexNotFoundException() {
+    }
+
+    public OpenSearchIndexNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/park/utmstack/web/rest/elasticsearch/ElasticsearchResource.java
+++ b/backend/src/main/java/com/park/utmstack/web/rest/elasticsearch/ElasticsearchResource.java
@@ -1,5 +1,6 @@
 package com.park.utmstack.web.rest.elasticsearch;
 
+import com.park.utmstack.util.exceptions.OpenSearchIndexNotFoundException;
 import com.utmstack.opensearch_connector.types.ElasticCluster;
 import com.park.utmstack.domain.application_events.enums.ApplicationEventType;
 import com.park.utmstack.domain.chart_builder.types.query.FilterType;
@@ -71,7 +72,7 @@ public class ElasticsearchResource {
         final String ctx = CLASSNAME + ".getFieldValuesWithCount";
         try {
             return ResponseEntity.ok(elasticsearchService.getFieldValuesWithCount(rq.getField(), rq.getIndex(),
-                rq.getFilters(), rq.getTop(), rq.isOrderByCount(), rq.isSortAsc()));
+                    rq.getFilters(), rq.getTop(), rq.isOrderByCount(), rq.isSortAsc()));
         } catch (Exception e) {
             String msg = ctx + ": " + e.getLocalizedMessage();
             log.error(msg);
@@ -91,11 +92,16 @@ public class ElasticsearchResource {
         final String ctx = CLASSNAME + ".getIndexProperties";
         try {
             return ResponseEntity.ok(elasticsearchService.getIndexProperties(indexPattern));
+        } catch (OpenSearchIndexNotFoundException e) {
+            String msg = ctx + ": " + e.getMessage();
+            log.info(msg);
+            applicationEventService.createEvent(msg, ApplicationEventType.INFO);
+            return UtilResponse.buildNotFoundResponse(msg);
         } catch (Exception e) {
             String msg = ctx + ": " + e.getMessage();
             log.error(msg);
             applicationEventService.createEvent(msg, ApplicationEventType.ERROR);
-            return UtilResponse.buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, msg);
+            return UtilResponse.buildInternalServerErrorResponse(msg);
         }
     }
 
@@ -132,7 +138,7 @@ public class ElasticsearchResource {
             log.error(msg);
             applicationEventService.createEvent(msg, ApplicationEventType.ERROR);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).headers(
-                HeaderUtil.createFailureAlert("", "", msg)).body(null);
+                    HeaderUtil.createFailureAlert("", "", msg)).body(null);
         }
     }
 
@@ -143,17 +149,17 @@ public class ElasticsearchResource {
         final String ctx = CLASSNAME + ".search";
         try {
             SearchResponse<Map> searchResponse = elasticsearchService.search(filters, top, indexPattern,
-                pageable, Map.class);
+                    pageable, Map.class);
 
             if (Objects.isNull(searchResponse) || Objects.isNull(searchResponse.hits()) || searchResponse.hits().total().value() == 0)
                 return ResponseEntity.ok(Collections.emptyList());
 
             HitsMetadata<Map> hits = searchResponse.hits();
             HttpHeaders headers = UtilPagination.generatePaginationHttpHeaders(Math.min(hits.total().value(), top),
-                pageable.getPageNumber(), pageable.getPageSize(), "/api/elasticsearch/search");
+                    pageable.getPageNumber(), pageable.getPageSize(), "/api/elasticsearch/search");
 
             return ResponseEntity.ok().headers(headers).body(hits.hits().stream()
-                .map(Hit::source).collect(Collectors.toList()));
+                    .map(Hit::source).collect(Collectors.toList()));
         } catch (Exception e) {
             String msg = ctx + ": " + e.getMessage();
             log.error(msg);
@@ -167,7 +173,7 @@ public class ElasticsearchResource {
         final String ctx = CLASSNAME + ".searchToCsv";
         try {
             SearchResponse<Map> searchResponse = elasticsearchService.search(params.getFilters(), params.getTop(),
-                params.getIndexPattern(), Pageable.unpaged(), Map.class);
+                    params.getIndexPattern(), Pageable.unpaged(), Map.class);
 
             if (Objects.isNull(searchResponse) || Objects.isNull(searchResponse.hits()) || searchResponse.hits().total().value() == 0)
                 return ResponseEntity.ok().build();
@@ -189,7 +195,7 @@ public class ElasticsearchResource {
         final String ctx = CLASSNAME + ".genericSearch";
         try {
             SearchResponse<Map> searchResponse = elasticsearchService.search(body.getFilters(), body.getTop(),
-                body.getIndex(), pageable, Map.class);
+                    body.getIndex(), pageable, Map.class);
 
             if (Objects.isNull(searchResponse) || Objects.isNull(searchResponse.hits()) || searchResponse.hits().total().value() == 0)
                 return ResponseEntity.ok().build();
@@ -197,10 +203,10 @@ public class ElasticsearchResource {
             HitsMetadata<Map> hits = searchResponse.hits();
 
             HttpHeaders headers = UtilPagination.generatePaginationHttpHeaders(Math.min(hits.total().value(), body.getTop()),
-                pageable.getPageNumber(), pageable.getPageSize(), "/api/elasticsearch/generic-search");
+                    pageable.getPageNumber(), pageable.getPageSize(), "/api/elasticsearch/generic-search");
 
             return ResponseEntity.ok().headers(headers).body(hits.hits().stream()
-                .map(Hit::source).collect(Collectors.toList()));
+                    .map(Hit::source).collect(Collectors.toList()));
         } catch (Exception e) {
             String msg = ctx + ": " + e.getMessage();
             log.error(msg);
@@ -214,7 +220,7 @@ public class ElasticsearchResource {
         final String ctx = CLASSNAME + ".getClusterStatus";
         try {
             return elasticsearchService.getClusterStatus().map(ResponseEntity::ok)
-                .orElseGet(() -> ResponseEntity.noContent().build());
+                    .orElseGet(() -> ResponseEntity.noContent().build());
         } catch (Exception e) {
             String msg = ctx + ": " + e.getLocalizedMessage();
             log.error(msg);


### PR DESCRIPTION
Responding with Not Found code in ElasticsearchResource.getIndexProperties method in case the index for which you are looking the properties does not exist