### PR TITLE
Escaping OpenSearch reserved characters for the query_string query

### DIFF
--- a/backend/src/main/java/com/park/utmstack/service/elasticsearch/SearchUtil.java
+++ b/backend/src/main/java/com/park/utmstack/service/elasticsearch/SearchUtil.java
@@ -3,6 +3,7 @@ package com.park.utmstack.service.elasticsearch;
 import com.park.utmstack.config.Constants;
 import com.park.utmstack.domain.chart_builder.types.query.FilterType;
 import com.park.utmstack.domain.chart_builder.types.query.OperatorType;
+import com.park.utmstack.util.CustomStringEscapeUtil;
 import com.park.utmstack.util.UtilPagination;
 import org.apache.commons.lang3.ObjectUtils;
 import org.opensearch.client.json.JsonData;
@@ -228,9 +229,10 @@ public class SearchUtil {
         final String ctx = CLASSNAME + ".buildIsInFields";
         try {
             filter.validate();
+            String value = CustomStringEscapeUtil.opensearchQueryStringEscape(String.valueOf(filter.getValue()));
             bool.filter(f -> f.queryString(q -> q
                 .defaultField("*")
-                .query("*" + filter.getValue() + "*")));
+                .query("*" + value + "*")));
         } catch (Exception e) {
             throw new RuntimeException(ctx + ": " + e.getLocalizedMessage());
         }
@@ -240,9 +242,10 @@ public class SearchUtil {
         final String ctx = CLASSNAME + ".buildIsNotInFields";
         try {
             filter.validate();
+            String value = CustomStringEscapeUtil.opensearchQueryStringEscape(String.valueOf(filter.getValue()));
             bool.filter(f -> f.bool(b -> b.mustNot(n -> n.queryString(q -> q
                 .defaultField("*")
-                .query("*" + filter.getValue() + "*")))));
+                .query("*" + value + "*")))));
         } catch (Exception e) {
             throw new RuntimeException(ctx + ": " + e.getLocalizedMessage());
         }

--- a/backend/src/main/java/com/park/utmstack/util/CustomStringEscapeUtil.java
+++ b/backend/src/main/java/com/park/utmstack/util/CustomStringEscapeUtil.java
@@ -1,0 +1,19 @@
+package com.park.utmstack.util;
+
+import org.apache.commons.text.translate.AggregateTranslator;
+import org.apache.commons.text.translate.LookupTranslator;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class CustomStringEscapeUtil {
+    public static String opensearchQueryStringEscape(String str) {
+        final String[] chars = new String[] {"+", "-", "=", "&&", "||", "!", "(", ")", "{", "}", "[", "]", "^", "\"", "~", "*", "?", ":", "\\", "/"};
+        final Map<CharSequence, CharSequence> escapeCustomMap = new HashMap<>();
+        escapeCustomMap.put("<", "");
+        escapeCustomMap.put(">", "");
+        for (String s : chars)
+            escapeCustomMap.put(s, "\\\\" + s);
+        return new AggregateTranslator(new LookupTranslator(escapeCustomMap)).translate(str);
+    }
+}


### PR DESCRIPTION
Reserved characters were escaped in the OpenSearch query_string query used by UTMStack's search operators IS_IN_FIELDS and IS_NOT_IN_FIELDS. We based on the list of reserved characters provided in OpenSearch documentation found at https://opensearch.org/docs/latest/query-dsl/full-text/query-string/#reserved-characters.