### PR TITLE
Fixing overwriting of the properties host and IP of the alert that is created for a data source down

### DIFF
--- a/backend/src/main/java/com/park/utmstack/service/UtmDataInputStatusService.java
+++ b/backend/src/main/java/com/park/utmstack/service/UtmDataInputStatusService.java
@@ -317,8 +317,8 @@ public class UtmDataInputStatusService {
         dst.put("aso", "");
         dst.put("asn", 0);
         dst.put("user", "");
-        src.put("ip", "");
-        src.put("host", "");
+        dst.put("ip", "");
+        dst.put("host", "");
 
         Map<String, Object> incidentDetails = new HashMap<>();
         incidentDetails.put("createdBy", "");


### PR DESCRIPTION
The alert details view was crashing due to this issue.