### PR TITLE
Correct conditional check for IP info search results

### DIFF
--- a/backend/src/main/java/com/park/utmstack/service/ip_info/IpInfoService.java
+++ b/backend/src/main/java/com/park/utmstack/service/ip_info/IpInfoService.java
@@ -44,7 +44,7 @@ public class IpInfoService {
 
             HitsMetadata<GeoIp> hits = elasticsearchService.search(sr, GeoIp.class).hits();
 
-            if (hits.total().value() < 0)
+            if (hits.total().value() <= 0)
                 return null;
 
             return hits.hits().get(0).source();


### PR DESCRIPTION
Updated the `getIpInfo` method to fix the conditional check when evaluating the total hits from the Elasticsearch search result. Changed the condition from `hits.total().value() < 0` to `hits.total().value() <= 0` to correctly handle cases where no search results are found, preventing potential `IndexOutOfBoundsException`.