### PR TITLE
Increase rules update interval to 72 hours.

### DIFF
--- a/correlation/rules/update.go
+++ b/correlation/rules/update.go
@@ -25,7 +25,7 @@ func Update(updateReady chan bool) {
 			updateReady <- true
 		}
 
-		log.Println("Rules updated, waiting for 48 hours to update again")
-		time.Sleep(48 * time.Hour)
+		log.Println("Rules updated, waiting for 72 hours to update again")
+		time.Sleep(72 * time.Hour)
 	}
 }


### PR DESCRIPTION
Previously, the update interval was set to 48 hours. This change extends the waiting period to 72 hours, potentially reducing system resource usage and update frequency.

# **PLEASE READ BEFORE CONTINUING**

To help us understand your contribution, please include the following in your pull request:

* A detailed explanation of the changes you've made.
* The reasoning behind these changes.
* A reference to the issue that this pull request addresses.
