### PR TITLE
Handle errors in rules folder removal and git clone process

### DIFF
--- a/correlation/rules/update.go
+++ b/correlation/rules/update.go
@@ -2,6 +2,7 @@ package rules
 
 import (
 	"log"
+	"os"
 	"os/exec"
 	"time"
 
@@ -15,10 +16,18 @@ func Update(updateReady chan bool) {
 		cnf := utils.GetConfig()
 
 		rm := exec.Command("rm", "-R", cnf.RulesFolder+"system")
-		_ = rm.Run()
+		err := rm.Run()
+		if err != nil {
+			log.Printf("Could not remove rules folder: %v", err)
+			os.Exit(1)
+		}
 
 		clone := exec.Command("git", "clone", "https://github.com/utmstack/rules.git", cnf.RulesFolder+"system")
-		_ = clone.Run()
+		err = clone.Run()
+		if err != nil {
+			log.Printf("Could not clone rules: %v", err)
+			os.Exit(1)
+		}
 
 		if first {
 			first = false


### PR DESCRIPTION
Previously, errors during the removal of the rules folder or cloning from the repository were ignored. This update adds error handling to log failures and exit the program when these operations fail, ensuring more robust error management.
