### PR TITLE
Fix logic error in rules folder existence check

### DIFF
--- a/correlation/rules/update.go
+++ b/correlation/rules/update.go
@@ -18,7 +18,7 @@ func Update(updateReady chan bool) {
 
 		f, err := os.Stat(cnf.RulesFolder + "system")
 		if err != nil {
-			if errors.Is(err, os.ErrNotExist) {
+			if !errors.Is(err, os.ErrNotExist) {
 				log.Printf("Could not get rules folder: %v", err)
 				os.Exit(1)
 			}


### PR DESCRIPTION
The condition for checking the non-existence of the rules folder was inverted, causing incorrect error handling. Adjusted the conditional to properly detect and handle missing folders.
