### PR TITLE
Ensure nil check before accessing file attributes

### DIFF
--- a/correlation/rules/update.go
+++ b/correlation/rules/update.go
@@ -24,7 +24,7 @@ func Update(updateReady chan bool) {
 			}
 		}
 
-		if f.IsDir() || f.Name() == "system" {
+		if f != nil && (f.IsDir() || f.Name() == "system") {
 			rm := exec.Command("rm", "-R", cnf.RulesFolder+"system")
 			err = rm.Run()
 			if err != nil {


### PR DESCRIPTION
Added a nil check for the file object to prevent potential runtime panics when accessing its attributes. This change ensures the program behaves reliably even if the file object is unexpectedly nil.