### PR TITLE
Refactor `RunCommand` to separate command name and arguments

### DIFF
--- a/correlation/utils/os.go
+++ b/correlation/utils/os.go
@@ -5,8 +5,8 @@ import (
 	"os/exec"
 )
 
-func RunCommand(command ...string) error {
-	cmd := exec.Command(command[0], command[1:]...)
+func RunCommand(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
 
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
Updated the `RunCommand` function to take the command name and arguments as separate parameters instead of a single combined string. This change enhances readability and aligns function usage with the standard `exec.Command` structure, promoting consistency.

This modification resolves potential ambiguity in how commands are parsed and executed, reducing the risk of errors and improving maintainability.

No specific issue is referenced for this