### PR TITLE
fix: snapshot timing to include only indices older than 24 hours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,3 @@
-# UTMStack 10.6.0 Release Notes
+# UTMStack 10.6.1 Release Notes
 ## Bug Fixes
-- Reorganized GeoIP database loading into more modular functions for improved maintainability and code readability. Simplified caching, removed unused database function, and restructured rule-handling logic. Improved consistency by standardizing variable names and logging practices.
-- Removed unused docker volume configuration for GeoIp.
-- Fixed Kernel modules weren't loaded because incorrect function call.
-
-## New Features
-- Introduced automatic threat intelligence rules to detect blacklisted ips, hostnames and domains.
+- Fixed ISM policy to ensure snapshots include only indices older than 24 hours.

--- a/backend/src/main/java/com/park/utmstack/service/index_policy/IndexPolicyService.java
+++ b/backend/src/main/java/com/park/utmstack/service/index_policy/IndexPolicyService.java
@@ -162,7 +162,7 @@ public class IndexPolicyService {
                     .ifPresent(state -> {
                         Transition transition = state.getTransitions().get(0);
                         transition.setStateName(Constants.STATE_BACKUP);
-                        transition.setConditions(null);
+                        transition.setConditions(new TransitionCondition("24h"));
                     });
 
                 // open -> safe_delete
@@ -178,6 +178,7 @@ public class IndexPolicyService {
                     .ifPresent(state -> {
                         Transition transition = state.getTransitions().get(0);
                         transition.setStateName(Constants.STATE_OPEN);
+                        transition.setConditions(new TransitionCondition("24h"));
                     });
 
                 // open -> delete

--- a/version.yml
+++ b/version.yml
@@ -1,1 +1,1 @@
-version: 10.6.0
+version: 10.6.1


### PR DESCRIPTION
This PR updates the ISM policy to ensure snapshots include only indices older than 24 hours by applying the correct transition condition.

Ensures snapshots follow the intended retention policy by applying the correct transition condition.

Issue Reference
https://github.com/utmstack/UTMStack/issues/1055