### PR TITLE
fix[frontend](log_explorer): fixed log explorer tab redirection handler

### DIFF
--- a/frontend/src/app/log-analyzer/explorer/log-analyzer-tabs/log-analyzer-tabs.component.ts
+++ b/frontend/src/app/log-analyzer/explorer/log-analyzer-tabs/log-analyzer-tabs.component.ts
@@ -1,7 +1,7 @@
 import {Component, OnDestroy, OnInit} from '@angular/core';
 import {ActivatedRoute, NavigationEnd, NavigationStart, Params, Router} from '@angular/router';
 import {UUID} from 'angular2-uuid';
-import {Observable, Subject} from 'rxjs';
+import {Observable, Subject,take} from 'rxjs';
 import {filter, takeUntil, tap} from 'rxjs/operators';
 import {UtmIndexPattern} from '../../../shared/types/index-pattern/utm-index-pattern';
 import {IndexPatternBehavior} from '../../shared/behaviors/index-pattern.behavior';
@@ -47,12 +47,12 @@ export class LogAnalyzerTabsComponent implements OnInit, OnDestroy {
             this.addNewTab(this.query.name, this.query, params);
           });
         } else {
-          if (this.tabService.getTabCount() ==0) {
-            this.addNewTab(null, null, params);
-          }
-          if(isRefresh){
-            this.updateCurrentTab(params)
-          }
+              this.tabSelected = this.tabService.getActiveTab()
+              if(isRefresh && !!this.tabSelected){
+                  this.updateCurrentTab(params)
+                  return
+              }
+              this.addNewTab(null, null, params);
         }
       });
 
@@ -81,7 +81,6 @@ export class LogAnalyzerTabsComponent implements OnInit, OnDestroy {
   }
 
   tabChanged(tab: TabType) {
-    console.log(tab)
     this.tabSelected = tab;
     this.tabService.setActiveTab(tab.id);
     this.indexPatternBehavior.changePattern({pattern: tab.tabData.pattern, tabUUID: tab.uuid});

--- a/frontend/src/app/log-analyzer/explorer/log-analyzer-view/log-analyzer-view.component.ts
+++ b/frontend/src/app/log-analyzer/explorer/log-analyzer-view/log-analyzer-view.component.ts
@@ -298,15 +298,16 @@ export class LogAnalyzerViewComponent implements OnInit, OnDestroy {
     this.sortBy = NatureDataPrefixEnum.TIMESTAMP + ',' + 'desc';
     this.pattern = pattern;
     this.fields = [{field: '@timestamp', type: ElasticDataTypesEnum.DATE, visible: true, label: '@timestamp'}];*/
+          this.router.navigate([], {
+            relativeTo: this.activatedRoute,
+            queryParams: {
+              patternId: pattern.id,
+              indexPattern: pattern.pattern,
+              refreshRoute: true
+            },
+          });
 
-    this.router.navigate([], {
-      relativeTo: this.activatedRoute,
-      queryParams: {
-        patternId: pattern.id,
-        indexPattern: pattern.pattern,
-        refreshRoute: true
-      },
-    });
+
   }
 
   saveQuery() {

--- a/frontend/src/app/log-analyzer/shared/services/tab.service.ts
+++ b/frontend/src/app/log-analyzer/shared/services/tab.service.ts
@@ -119,7 +119,6 @@ export class TabService {
    */
   private emitTabs(): void {
     //avoiding javascript to send references to the subject
-    const tabsDeepcopy = JSON.parse(JSON.stringify(this.tabs))
     this.tabSubject.next([...this.tabs]);
   }
 }

--- a/frontend/src/app/shared/components/utm/index-pattern/index-pattern-select/index-pattern-select.component.html
+++ b/frontend/src/app/shared/components/utm/index-pattern/index-pattern-select/index-pattern-select.component.html
@@ -36,7 +36,7 @@
 </ng-container>
 
 <ng-template #popContent>
-  <app-utm-selectable-list [itemTemplate]="item" [label]="'Sources'" [items]="indexPatternList" (itemSelected)="selectedPattern($event)">
+  <app-utm-selectable-list [itemTemplate]="item" [label]="'Sources'" [items]="indexPatternList" (itemSelected)="selectedPattern($event,popover)">
     <div add-item class="custom-flex-item custom-flex-item-grow-zero">
           <span (click)="newIndexPattern();popover.close()" class="span-small-icon text-blue-800 cursor-pointer">
             <i class="icon-plus3"></i> Add source

--- a/frontend/src/app/shared/components/utm/index-pattern/index-pattern-select/index-pattern-select.component.ts
+++ b/frontend/src/app/shared/components/utm/index-pattern/index-pattern-select/index-pattern-select.component.ts
@@ -77,9 +77,10 @@ export class IndexPatternSelectComponent implements OnInit {
     return this.patterns.map(pattern => ({ id: pattern.id, name: pattern.pattern, selected: this.pattern.id == pattern.id }));
   }
 
-  selectedPattern($event) {
+  selectedPattern($event,popover) {
     this.pattern = this.patterns.find(p => p.id === $event.id);
     this.indexPatternList = this.getListPatterns();
     this.indexPatternChange.emit(this.pattern);
+     popover.close();
   }
 }

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -4,8 +4,8 @@
 
 export const environment = {
   production: false,
-  SERVER_API_URL: 'https://192.168.1.18/',
-  //SERVER_API_URL: 'http://localhost:8080/',
+  // SERVER_API_URL: 'https://192.168.1.18/',
+  SERVER_API_URL: 'http://localhost:8080/',
   SERVER_API_CONTEXT: '',
   SESSION_AUTH_TOKEN: window.location.host.split(':')[0].toLocaleUpperCase(),
   WEBSOCKET_URL: '//localhost:8080',


### PR DESCRIPTION
#Main Changes:

- fixed query param catching logic on log explorer
- fixed null selected tab on header menu redirecton that was causing tab duplication and filter ignoration
- forced popover close after filter is selected
