### PR TITLE
fix: change file permissions from 777 to 755 for security improvements

### DIFF
--- a/agent/collectors/filebeat_amd64.go
+++ b/agent/collectors/filebeat_amd64.go
@@ -66,7 +66,7 @@ func (f Filebeat) Install() error {
 				return fmt.Errorf("error creating %s service: %v", config.ModulesServName, err)
 			}
 
-			if err = utils.Execute("chmod", filebLogPath, "-R", "777", "filebeat"); err != nil {
+			if err = utils.Execute("chmod", filebLogPath, "-R", "755", "filebeat"); err != nil {
 				return fmt.Errorf("error executing chmod: %v", err)
 			}
 

--- a/agent/updates/dependencies.go
+++ b/agent/updates/dependencies.go
@@ -39,7 +39,7 @@ func handleDependenciesPostDownload(dependencies []string) error {
 			}
 
 			if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
-				if err := utils.Execute("chmod", utils.GetMyPath(), "-R", "777", fmt.Sprintf(config.UpdaterSelf, "")); err != nil {
+				if err := utils.Execute("chmod", utils.GetMyPath(), "-R", "755", fmt.Sprintf(config.UpdaterSelf, "")); err != nil {
 					return fmt.Errorf("error executing chmod on %s: %v", fmt.Sprintf(config.UpdaterSelf, ""), err)
 				}
 			}
@@ -48,7 +48,7 @@ func handleDependenciesPostDownload(dependencies []string) error {
 				return fmt.Errorf("error removing file %s: %v", file, err)
 			}
 		} else if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
-			if err := utils.Execute("chmod", utils.GetMyPath(), "-R", "777", file); err != nil {
+			if err := utils.Execute("chmod", utils.GetMyPath(), "-R", "755", file); err != nil {
 				return fmt.Errorf("error executing chmod on %s: %v", file, err)
 			}
 		}

--- a/agent/updates/update.go
+++ b/agent/updates/update.go
@@ -55,7 +55,7 @@ func UpdateDependencies(cnf *config.Config) {
 			}
 
 			if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
-				if err = utils.Execute("chmod", utils.GetMyPath(), "-R", "777", filepath.Join(utils.GetMyPath(), fmt.Sprintf(config.ServiceFile, "_new"))); err != nil {
+				if err = utils.Execute("chmod", utils.GetMyPath(), "-R", "755", filepath.Join(utils.GetMyPath(), fmt.Sprintf(config.ServiceFile, "_new"))); err != nil {
 					utils.Logger.ErrorF("error executing chmod: %v", err)
 				}
 			}

--- a/etc/opensearch/2.x/Dockerfile
+++ b/etc/opensearch/2.x/Dockerfile
@@ -35,7 +35,7 @@ RUN yum update -y && \
     rm -rf /usr/share/man /usr/share/doc /usr/share/info /tmp/* /var/tmp/*
 
 # Assign permissions and ownership to the extracted folder
-RUN chmod -R 777 /usr/share/opensearch/.utm_geoip && \
+RUN chmod -R 755 /usr/share/opensearch/.utm_geoip && \
     chown -R opensearch:opensearch /usr/share/opensearch/.utm_geoip
 
 # Restore OpenSearch user

--- a/frontend/src/app/app-module/guides/guide-as400/constants.ts
+++ b/frontend/src/app/app-module/guides/guide-as400/constants.ts
@@ -32,7 +32,7 @@ export const PLATFORM = [
                   `/opt/utmstack-linux-collectors/as400 && cd /opt/utmstack-linux-collectors/as400 && ` +
                   `wget --no-check-certificate ` +
                   `https://V_IP:9001/private/dependencies/collector/linux-as400-collector.zip ` +
-                  `&& unzip linux-as400-collector.zip && rm linux-as400-collector.zip && chmod -R 777 ` +
+                  `&& unzip linux-as400-collector.zip && rm linux-as400-collector.zip && chmod -R 755 ` +
                   `utmstack_collectors_installer && ./utmstack_collectors_installer install as400 ` +
                   `V_IP <secret>V_TOKEN<secret>"`,
 

--- a/frontend/src/app/app-module/guides/guide-linux-agent/guide-linux-agent.component.ts
+++ b/frontend/src/app/app-module/guides/guide-linux-agent/guide-linux-agent.component.ts
@@ -39,7 +39,7 @@ export class GuideLinuxAgentComponent implements OnInit {
     return `sudo bash -c "apt update -y && apt install wget -y && mkdir -p /opt/utmstack-linux-agent && \
     wget --no-check-certificate -P /opt/utmstack-linux-agent \
     https://${ip}:9001/private/dependencies/agent/${installerName} && \
-    chmod -R 777 /opt/utmstack-linux-agent/${installerName} && \
+    chmod -R 755 /opt/utmstack-linux-agent/${installerName} && \
     /opt/utmstack-linux-agent/${installerName} install ${ip} <secret>${this.token}</secret> yes"`;
   }
 
@@ -49,7 +49,7 @@ export class GuideLinuxAgentComponent implements OnInit {
     return `sudo bash -c "yum install wget -y && mkdir -p /opt/utmstack-linux-agent && \
     wget --no-check-certificate -P /opt/utmstack-linux-agent \
     https://${ip}:9001/private/dependencies/agent/${installerName} && \
-    chmod -R 777 /opt/utmstack-linux-agent/${installerName} && \
+    chmod -R 755 /opt/utmstack-linux-agent/${installerName} && \
     /opt/utmstack-linux-agent/${installerName} install ${ip} <secret>${this.token}</secret> yes"`;
   }
 
@@ -59,7 +59,7 @@ export class GuideLinuxAgentComponent implements OnInit {
     return `sudo bash -c "dnf install wget -y && mkdir -p /opt/utmstack-linux-agent && \
     wget --no-check-certificate -P /opt/utmstack-linux-agent \
     https://${ip}:9001/private/dependencies/agent/${installerName} && \
-    chmod -R 777 /opt/utmstack-linux-agent/${installerName} && \
+    chmod -R 755 /opt/utmstack-linux-agent/${installerName} && \
     /opt/utmstack-linux-agent/${installerName} install ${ip} <secret>${this.token}</secret> yes"`;
   }
 


### PR DESCRIPTION
This pull request standardizes file and directory permissions across the codebase by changing `chmod` commands from `777` (full access for everyone) to `755` (full access for owner, read/execute for others). This improves security by reducing unnecessary write access for group and other users. The changes affect backend installation logic, update procedures, Dockerfile setup, and user-facing installation instructions.

**Backend installation and update logic:**
* Changed `chmod` arguments from `777` to `755` in `agent/collectors/filebeat_amd64.go`, `agent/updates/dependencies.go`, and `agent/updates/update.go` to restrict permissions when installing or updating files and services. [[1]](diffhunk://#diff-6436140029bd65a40b9e668036be42e3c199c32d4664f51a41ae6dbfc1819a1cL69-R69) [[2]](diffhunk://#diff-3bf5e0740cd83b47f38cf79d2438f74113c88b30167682a1a260c5bd10d3d675L42-R42) [[3]](diffhunk://#diff-3bf5e0740cd83b47f38cf79d2438f74113c88b30167682a1a260c5bd10d3d675L51-R51) [[4]](diffhunk://#diff-a97401859115b0a5c1359e0642f69131aaaf1aa4eb5d8e06ab57ae16bc21b27bL58-R58)

**Dockerfile permissions:**
* Updated the `chmod` command in `etc/opensearch/2.x/Dockerfile` to use `755` instead of `777` for the `.utm_geoip` directory, enhancing container security.

**Frontend installation instructions:**
* Modified installation command strings in `frontend/src/app/app-module/guides/guide-as400/constants.ts` and `frontend/src/app/app-module/guides/guide-linux-agent/guide-linux-agent.component.ts` to set permissions to `755` instead of `777` for agent and collector installers, aligning user guidance with backend changes. [[1]](diffhunk://#diff-d5f42bd90a0b2c3baf7f91cfc02a9e5c2f75397f27eb86f93a4ffd446430812dL35-R35) [[2]](diffhunk://#diff-f7dbe57c664df652fe58197c4f9518af1121705455e33bf71ab0d21be046db02L42-R42) [[3]](diffhunk://#diff-f7dbe57c664df652fe58197c4f9518af1121705455e33bf71ab0d21be046db02L52-R52) [[4]](diffhunk://#diff-f7dbe57c664df652fe58197c4f9518af1121705455e33bf71ab0d21be046db02L62-R62)
