### PR TITLE
refactor(agent-manager): remove gzip middleware, update TLS configura…

### DIFF
--- a/agent-manager/updates/updates.go
+++ b/agent-manager/updates/updates.go
@@ -4,8 +4,8 @@ import (
 	"crypto/tls"
 	"net/http"
 	"os"
+	"time"
 
-	"github.com/gin-contrib/gzip"
 	"github.com/threatwinds/go-sdk/catcher"
 
 	"github.com/gin-gonic/gin"
@@ -23,7 +23,6 @@ func ServeDependencies() {
 	r := gin.New()
 	r.Use(
 		gin.Recovery(),
-		gzip.Gzip(gzip.DefaultCompression),
 	)
 
 	r.NoRoute(notFound)
@@ -33,20 +32,31 @@ func ServeDependencies() {
 
 	loadedCert, err := tls.LoadX509KeyPair(config.CertPath, config.CertKeyPath)
 	if err != nil {
-		catcher.Error("failed to load TLS credentials", err, map[string]any{"process": "agent-manager"})
+		_ = catcher.Error("failed to load TLS credentials", err, map[string]any{"process": "agent-manager"})
+		time.Sleep(5 * time.Second)
 		os.Exit(1)
 	}
 
 	tlsConfig := &tls.Config{
-		MinVersion:   tls.VersionTLS12,
 		Certificates: []tls.Certificate{loadedCert},
+		MinVersion:   tls.VersionTLS12,
+		MaxVersion:   tls.VersionTLS13,
 		CipherSuites: []uint16{
-			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			// TLS 1.2 secure cipher suites - RSA key exchange
 			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			// TLS 1.2 secure cipher suites - ECDSA key exchange (for ECDSA certificates)
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 		},
-
-		PreferServerCipherSuites: true,
+		CurvePreferences: []tls.CurveID{
+			tls.X25519,    // Modern and fast
+			tls.CurveP256, // NIST P-256
+			tls.CurveP384, // NIST P-384
+			tls.CurveP521, // NIST P-521
+		},
 	}
 
 	server := &http.Server{
@@ -57,7 +67,7 @@ func ServeDependencies() {
 
 	catcher.Info("Starting HTTP server on port 8080", map[string]any{"process": "agent-manager"})
 	if err := server.ListenAndServeTLS("", ""); err != nil {
-		catcher.Error("error starting HTTP server", err, map[string]any{"process": "agent-manager"})
+		_ = catcher.Error("error starting HTTP server", err, map[string]any{"process": "agent-manager"})
 		return
 	}
 }


### PR DESCRIPTION
This pull request updates the TLS configuration and error handling in the `agent-manager/updates/updates.go` file to improve security and reliability. It also removes gzip middleware from the Gin server setup.

**TLS configuration improvements:**

* Expanded the list of supported cipher suites to include both RSA and ECDSA key exchanges, added support for TLS 1.3, and set preferred elliptic curves for better security. (`agent-manager/updates/updates.go`)
* Set both minimum and maximum TLS versions (`MinVersion: tls.VersionTLS12`, `MaxVersion: tls.VersionTLS13`) for stricter protocol enforcement. (`agent-manager/updates/updates.go`)

**Error handling improvements:**

* Updated error logging to ignore the return value from `catcher.Error` and added a 5-second delay before exiting if TLS credentials fail to load, which may help with debugging or orchestrator restarts. (`agent-manager/updates/updates.go`) [[1]](diffhunk://#diff-149104d71268dfc124f746eeb4b460ff587c7de093c3ba925fd8411a0b685664L36-L49) [[2]](diffhunk://#diff-149104d71268dfc124f746eeb4b460ff587c7de093c3ba925fd8411a0b685664L60-R70)

**Middleware changes:**

* Removed the `gzip` middleware from the Gin server, so HTTP responses are no longer compressed with gzip by default. (`agent-manager/updates/updates.go`) [[1]](diffhunk://#diff-149104d71268dfc124f746eeb4b460ff587c7de093c3ba925fd8411a0b685664R7-L8) [[2]](diffhunk://#diff-149104d71268dfc124f746eeb4b460ff587c7de093c3ba925fd8411a0b685664L26)