### PR TITLE
Release/v11.2.7

### DIFF
--- a/agent/dependency/dependency.go
+++ b/agent/dependency/dependency.go
@@ -21,6 +21,29 @@ const (
 	MacosCollectorVersion = "11.2.3"
 )
 
+// getUpdaterVersion reads the desired updater version from version.json
+// (the updater_version field). Falls back to UpdaterVersion if the
+// file is missing, unreadable, or the field is empty.
+//
+// The source of truth for this value is version.json shipped by the server,
+// which the updater promotes on each successful agent update.
+func getUpdaterVersion() string {
+	var v struct {
+		UpdaterVersion string `json:"updater_version"`
+	}
+	versionPath := filepath.Join(fs.GetExecutablePath(), "version.json")
+	if !fs.Exists(versionPath) {
+		return UpdaterVersion
+	}
+	if err := fs.ReadJSON(versionPath, &v); err != nil {
+		return UpdaterVersion
+	}
+	if v.UpdaterVersion == "" {
+		return UpdaterVersion
+	}
+	return v.UpdaterVersion
+}
+
 // UpdaterFile returns the updater binary name with OS and architecture suffix.
 // Format: utmstack_updater_service_<os>_<arch>[.exe]
 // Examples:
@@ -43,6 +66,7 @@ type Dependency struct {
 	DownloadURL  func(server string) string // URL template to download from
 	DownloadName string                     // Filename to save as (if different from BinaryPath basename)
 	Critical     bool                       // If true, failure blocks agent startup
+	PreDownload  func() (cleanup func(), err error) // Called before download, returns cleanup for rollback
 	PostDownload func() error               // Run after download (e.g., unzip). Can be nil.
 	Configure    func() error               // Run on first install (can be nil)
 	Update       func() error               // Run on version change (can be nil, uses Configure)
@@ -188,12 +212,33 @@ func Reconcile(server string, skipCertValidation bool) error {
 		} else if inst.Version != dep.Version {
 			// VERSION CHANGED: Download (if needed) and update
 			utils.Logger.Info("Updating dependency: %s (%s -> %s)", dep.Name, inst.Version, dep.Version)
+			
+			// Call PreDownload hook if defined
+			var cleanup func()
+			if dep.PreDownload != nil {
+				var err error
+				cleanup, err = dep.PreDownload()
+				if err != nil {
+					errMsg := fmt.Errorf("failed to run PreDownload for %s: %v", dep.Name, err)
+					utils.Logger.ErrorF("%v", errMsg)
+					if dep.Critical {
+						criticalErrors = append(criticalErrors, errMsg)
+					}
+					continue
+				}
+			}
+
 			if dep.DownloadURL != nil {
 				if err := downloadDependency(dep, server, skipCertValidation); err != nil {
 					errMsg := fmt.Errorf("failed to download dependency update %s: %v", dep.Name, err)
 					utils.Logger.ErrorF("%v", errMsg)
 					if dep.Critical {
 						criticalErrors = append(criticalErrors, errMsg)
+					}
+					// Rollback: call cleanup if PreDownload succeeded
+					if cleanup != nil {
+						utils.Logger.Info("Rolling back PreDownload changes for %s", dep.Name)
+						cleanup()
 					}
 					continue
 				}
@@ -209,6 +254,11 @@ func Reconcile(server string, skipCertValidation bool) error {
 					utils.Logger.ErrorF("%v", errMsg)
 					if dep.Critical {
 						criticalErrors = append(criticalErrors, errMsg)
+					}
+					// Rollback: call cleanup if PreDownload succeeded
+					if cleanup != nil {
+						utils.Logger.Info("Rolling back PreDownload changes for %s", dep.Name)
+						cleanup()
 					}
 					continue
 				}

--- a/agent/dependency/deps_darwin.go
+++ b/agent/dependency/deps_darwin.go
@@ -10,6 +10,7 @@ import (
 	"github.com/utmstack/UTMStack/agent/config"
 	"github.com/utmstack/UTMStack/shared/exec"
 	"github.com/utmstack/UTMStack/shared/fs"
+	"github.com/utmstack/UTMStack/shared/svc"
 )
 
 const macosCollectorBinary = "utmstack-collector-mac"
@@ -20,15 +21,16 @@ func GetDependencies() []Dependency {
 
 	return []Dependency{
 		{
-			Name:       "updater",
-			Version:    UpdaterVersion,
-			BinaryPath: filepath.Join(basePath, UpdaterFile("")),
+			Name:        "updater",
+			Version:     getUpdaterVersion(),
+			BinaryPath:  filepath.Join(basePath, UpdaterFile("")),
 			DownloadURL: func(server string) string {
 				return fmt.Sprintf(config.DependUrl, server, config.DependenciesPort, UpdaterFile(""))
 			},
-			Critical:  false,
-			Configure: configureUpdater,
-			Uninstall: uninstallUpdater,
+			Critical:    false,
+			PreDownload: preDownloadUpdater,
+			Configure:   configureUpdater,
+			Uninstall:   uninstallUpdater,
 		},
 		{
 			Name:       "macos-collector",
@@ -65,4 +67,20 @@ func uninstallUpdater() error {
 		return nil
 	}
 	return exec.Run(updaterPath, fs.GetExecutablePath(), "uninstall")
+}
+
+func preDownloadUpdater() (func(), error) {
+	// Stop the updater service before download
+	if err := svc.Stop(config.SERVICE_UPDATER_NAME); err != nil {
+		// Service might not be running or installed yet - that's OK
+		// Return cleanup function anyway (safe to start)
+		return func() {
+			_ = svc.Start(config.SERVICE_UPDATER_NAME)
+		}, nil
+	}
+	
+	// Return cleanup function that restarts the service
+	return func() {
+		_ = svc.Start(config.SERVICE_UPDATER_NAME)
+	}, nil
 }

--- a/agent/dependency/deps_linux_amd64.go
+++ b/agent/dependency/deps_linux_amd64.go
@@ -11,6 +11,7 @@ import (
 	"github.com/utmstack/UTMStack/agent/config"
 	"github.com/utmstack/UTMStack/shared/exec"
 	"github.com/utmstack/UTMStack/shared/fs"
+	"github.com/utmstack/UTMStack/shared/svc"
 )
 
 // GetDependencies returns the list of dependencies for Linux amd64.
@@ -19,15 +20,16 @@ func GetDependencies() []Dependency {
 
 	return []Dependency{
 		{
-			Name:       "updater",
-			Version:    UpdaterVersion,
-			BinaryPath: filepath.Join(basePath, UpdaterFile("")),
+			Name:        "updater",
+			Version:     getUpdaterVersion(),
+			BinaryPath:  filepath.Join(basePath, UpdaterFile("")),
 			DownloadURL: func(server string) string {
 				return fmt.Sprintf(config.DependUrl, server, config.DependenciesPort, UpdaterFile(""))
 			},
-			Critical:  false,
-			Configure: configureUpdater,
-			Uninstall: uninstallUpdater,
+			Critical:    false,
+			PreDownload: preDownloadUpdater,
+			Configure:   configureUpdater,
+			Uninstall:   uninstallUpdater,
 		},
 
 		// New beats dependency - only for uninstalling existing filebeat/winlogbeat
@@ -74,4 +76,20 @@ func uninstallUpdater() error {
 
 func uninstallBeats() error {
 	return collector.UninstallAll()
+}
+
+func preDownloadUpdater() (func(), error) {
+	// Stop the updater service before download
+	if err := svc.Stop(config.SERVICE_UPDATER_NAME); err != nil {
+		// Service might not be running or installed yet - that's OK
+		// Return cleanup function anyway (safe to start)
+		return func() {
+			_ = svc.Start(config.SERVICE_UPDATER_NAME)
+		}, nil
+	}
+	
+	// Return cleanup function that restarts the service
+	return func() {
+		_ = svc.Start(config.SERVICE_UPDATER_NAME)
+	}, nil
 }

--- a/agent/dependency/deps_linux_arm64.go
+++ b/agent/dependency/deps_linux_arm64.go
@@ -10,6 +10,7 @@ import (
 	"github.com/utmstack/UTMStack/agent/config"
 	"github.com/utmstack/UTMStack/shared/exec"
 	"github.com/utmstack/UTMStack/shared/fs"
+	"github.com/utmstack/UTMStack/shared/svc"
 )
 
 // GetDependencies returns the list of dependencies for Linux arm64.
@@ -19,15 +20,16 @@ func GetDependencies() []Dependency {
 
 	return []Dependency{
 		{
-			Name:       "updater",
-			Version:    UpdaterVersion,
-			BinaryPath: filepath.Join(basePath, UpdaterFile("")),
+			Name:        "updater",
+			Version:     getUpdaterVersion(),
+			BinaryPath:  filepath.Join(basePath, UpdaterFile("")),
 			DownloadURL: func(server string) string {
 				return fmt.Sprintf(config.DependUrl, server, config.DependenciesPort, UpdaterFile(""))
 			},
-			Critical:  false,
-			Configure: configureUpdater,
-			Uninstall: uninstallUpdater,
+			Critical:    false,
+			PreDownload: preDownloadUpdater,
+			Configure:   configureUpdater,
+			Uninstall:   uninstallUpdater,
 		},
 
 		// Auditd dependency - auto-configures Linux audit daemon
@@ -60,4 +62,20 @@ func uninstallUpdater() error {
 		return nil
 	}
 	return exec.Run(updaterPath, fs.GetExecutablePath(), "uninstall")
+}
+
+func preDownloadUpdater() (func(), error) {
+	// Stop the updater service before download
+	if err := svc.Stop(config.SERVICE_UPDATER_NAME); err != nil {
+		// Service might not be running or installed yet - that's OK
+		// Return cleanup function anyway (safe to start)
+		return func() {
+			_ = svc.Start(config.SERVICE_UPDATER_NAME)
+		}, nil
+	}
+	
+	// Return cleanup function that restarts the service
+	return func() {
+		_ = svc.Start(config.SERVICE_UPDATER_NAME)
+	}, nil
 }

--- a/agent/dependency/deps_windows_amd64.go
+++ b/agent/dependency/deps_windows_amd64.go
@@ -11,6 +11,7 @@ import (
 	"github.com/utmstack/UTMStack/agent/config"
 	"github.com/utmstack/UTMStack/shared/exec"
 	"github.com/utmstack/UTMStack/shared/fs"
+	"github.com/utmstack/UTMStack/shared/svc"
 )
 
 // GetDependencies returns the list of dependencies for Windows amd64.
@@ -19,15 +20,16 @@ func GetDependencies() []Dependency {
 
 	return []Dependency{
 		{
-			Name:       "updater",
-			Version:    UpdaterVersion,
-			BinaryPath: filepath.Join(basePath, UpdaterFile("")),
+			Name:        "updater",
+			Version:     getUpdaterVersion(),
+			BinaryPath:  filepath.Join(basePath, UpdaterFile("")),
 			DownloadURL: func(server string) string {
 				return fmt.Sprintf(config.DependUrl, server, config.DependenciesPort, UpdaterFile(""))
 			},
-			Critical:  false, // Agent can run without updater
-			Configure: configureUpdater,
-			Uninstall: uninstallUpdater,
+			Critical:    false, // Agent can run without updater
+			PreDownload: preDownloadUpdater,
+			Configure:   configureUpdater,
+			Uninstall:   uninstallUpdater,
 		},
 
 		// New beats dependency - only for uninstalling existing filebeat/winlogbeat
@@ -56,4 +58,20 @@ func uninstallUpdater() error {
 
 func uninstallBeats() error {
 	return collector.UninstallAll()
+}
+
+func preDownloadUpdater() (func(), error) {
+	// Stop the updater service before download
+	if err := svc.Stop(config.SERVICE_UPDATER_NAME); err != nil {
+		// Service might not be running or installed yet - that's OK
+		// Return cleanup function anyway (safe to start)
+		return func() {
+			_ = svc.Start(config.SERVICE_UPDATER_NAME)
+		}, nil
+	}
+	
+	// Return cleanup function that restarts the service
+	return func() {
+		_ = svc.Start(config.SERVICE_UPDATER_NAME)
+	}, nil
 }

--- a/agent/dependency/deps_windows_arm64.go
+++ b/agent/dependency/deps_windows_arm64.go
@@ -10,6 +10,7 @@ import (
 	"github.com/utmstack/UTMStack/agent/config"
 	"github.com/utmstack/UTMStack/shared/exec"
 	"github.com/utmstack/UTMStack/shared/fs"
+	"github.com/utmstack/UTMStack/shared/svc"
 )
 
 // GetDependencies returns the list of dependencies for Windows arm64.
@@ -19,15 +20,16 @@ func GetDependencies() []Dependency {
 
 	return []Dependency{
 		{
-			Name:       "updater",
-			Version:    UpdaterVersion,
-			BinaryPath: filepath.Join(basePath, UpdaterFile("")),
+			Name:        "updater",
+			Version:     getUpdaterVersion(),
+			BinaryPath:  filepath.Join(basePath, UpdaterFile("")),
 			DownloadURL: func(server string) string {
 				return fmt.Sprintf(config.DependUrl, server, config.DependenciesPort, UpdaterFile(""))
 			},
-			Critical:  false,
-			Configure: configureUpdater,
-			Uninstall: uninstallUpdater,
+			Critical:    false,
+			PreDownload: preDownloadUpdater,
+			Configure:   configureUpdater,
+			Uninstall:   uninstallUpdater,
 		},
 	}
 }
@@ -43,4 +45,20 @@ func uninstallUpdater() error {
 		return nil
 	}
 	return exec.Run(updaterPath, fs.GetExecutablePath(), "uninstall")
+}
+
+func preDownloadUpdater() (func(), error) {
+	// Stop the updater service before download
+	if err := svc.Stop(config.SERVICE_UPDATER_NAME); err != nil {
+		// Service might not be running or installed yet - that's OK
+		// Return cleanup function anyway (safe to start)
+		return func() {
+			_ = svc.Start(config.SERVICE_UPDATER_NAME)
+		}, nil
+	}
+	
+	// Return cleanup function that restarts the service
+	return func() {
+		_ = svc.Start(config.SERVICE_UPDATER_NAME)
+	}, nil
 }

--- a/agent/updater/updates/update.go
+++ b/agent/updater/updates/update.go
@@ -136,6 +136,32 @@ func runUpdateProcess(basePath string) error {
 		return fmt.Errorf("error renaming new binary: %v", err)
 	}
 
+	// Promote version.json BEFORE starting the agent so that the new agent's
+	// dependency.Reconcile() sees the new updater_version on first boot.
+	// If anything fails after this, rollback restores the previous version.json.
+	versionNewPath := filepath.Join(basePath, "version_new.json")
+	versionPath := filepath.Join(basePath, "version.json")
+	versionBackupPath := filepath.Join(basePath, "version.json.old")
+
+	os.Remove(versionBackupPath)
+	versionBackedUp := false
+	if fs.Exists(versionPath) {
+		if err := os.Rename(versionPath, versionBackupPath); err != nil {
+			os.Rename(filepath.Join(basePath, oldBin), filepath.Join(basePath, newBin))
+			os.Rename(backupPath, filepath.Join(basePath, oldBin))
+			return fmt.Errorf("error backing up version.json: %v", err)
+		}
+		versionBackedUp = true
+	}
+	if err := os.Rename(versionNewPath, versionPath); err != nil {
+		if versionBackedUp {
+			os.Rename(versionBackupPath, versionPath)
+		}
+		os.Rename(filepath.Join(basePath, oldBin), filepath.Join(basePath, newBin))
+		os.Rename(backupPath, filepath.Join(basePath, oldBin))
+		return fmt.Errorf("error promoting version.json: %v", err)
+	}
+
 	if err := svc.Start(config.SERV_AGENT_NAME); err != nil {
 		rollbackAgent(oldBin, backupBin, basePath)
 		return fmt.Errorf("error starting agent: %v", err)
@@ -151,16 +177,7 @@ func runUpdateProcess(basePath string) error {
 	}
 
 	logger.Info("Health check passed for agent")
-
-	versionNewPath := filepath.Join(basePath, "version_new.json")
-	versionPath := filepath.Join(basePath, "version.json")
-	if fs.Exists(versionNewPath) {
-		if err := os.Rename(versionNewPath, versionPath); err != nil {
-			logger.Error("error updating version file: %v", err)
-		} else {
-			logger.Info("Version file updated successfully")
-		}
-	}
+	os.Remove(versionBackupPath)
 
 	return nil
 }
@@ -172,6 +189,14 @@ func rollbackAgent(currentBin, backupBin, basePath string) {
 
 	os.Remove(filepath.Join(basePath, currentBin))
 	os.Rename(filepath.Join(basePath, backupBin), filepath.Join(basePath, currentBin))
+
+	// Restore previous version.json if it was backed up during promotion.
+	versionPath := filepath.Join(basePath, "version.json")
+	versionBackupPath := filepath.Join(basePath, "version.json.old")
+	if fs.Exists(versionBackupPath) {
+		os.Remove(versionPath)
+		os.Rename(versionBackupPath, versionPath)
+	}
 
 	svc.Start(config.SERV_AGENT_NAME)
 	os.Remove(filepath.Join(basePath, "version_new.json"))

--- a/agent/updater/updates/update.go
+++ b/agent/updater/updates/update.go
@@ -106,8 +106,6 @@ func runUpdateProcess(basePath string) error {
 		return fmt.Errorf("error stopping agent: %v", err)
 	}
 
-	time.Sleep(10 * time.Second)
-
 	// Migration: check if old naming convention exists and migrate to new naming
 	oldBinPath := filepath.Join(basePath, oldBin)
 	if !fs.Exists(oldBinPath) {
@@ -171,7 +169,6 @@ func rollbackAgent(currentBin, backupBin, basePath string) {
 	logger.Info("Rolling back agent to previous version...")
 
 	svc.Stop(config.SERV_AGENT_NAME)
-	time.Sleep(5 * time.Second)
 
 	os.Remove(filepath.Join(basePath, currentBin))
 	os.Rename(filepath.Join(basePath, backupBin), filepath.Join(basePath, currentBin))

--- a/agent/version.json
+++ b/agent/version.json
@@ -1,4 +1,4 @@
 {
-    "version": "11.1.5",
-    "updater_version": "1.0.4"
+    "version": "11.1.4",
+    "updater_version": "1.0.5"
 }

--- a/agent/version.json
+++ b/agent/version.json
@@ -1,4 +1,4 @@
 {
-    "version": "11.1.4",
+    "version": "11.1.5",
     "updater_version": "1.0.5"
 }

--- a/filters/aws/aws.yml
+++ b/filters/aws/aws.yml
@@ -130,7 +130,7 @@ pipeline:
       - rename:
           from:
             - log.requestParameters.bucketName
-          to: log.userIdentityAccesrequestParametersBucketNamesKeyId
+          to: log.userIdentityAccessrequestParametersBucketNamesKeyId
 
       - rename:
           from:

--- a/shared/svc/svc_windows.go
+++ b/shared/svc/svc_windows.go
@@ -7,24 +7,59 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"time"
 )
 
-// Start starts a Windows service by name.
+const (
+	pollInterval = 500 * time.Millisecond
+	stopTimeout  = 60 * time.Second
+	startTimeout = 60 * time.Second
+)
+
+// Start starts a Windows service by name and waits until it's running.
 func Start(serviceName string) error {
-	cmd := exec.Command("sc", "start", serviceName)
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to start service %s: %w", serviceName, err)
+	// Already running? Nothing to do
+	if running, _ := IsActive(serviceName); running {
+		return nil
 	}
-	return nil
+
+	cmd := exec.Command("sc", "start", serviceName)
+	cmd.Run() // Ignore error, we'll check actual state
+
+	// Poll until running or timeout
+	deadline := time.Now().Add(startTimeout)
+	for time.Now().Before(deadline) {
+		if running, _ := IsActive(serviceName); running {
+			return nil
+		}
+		time.Sleep(pollInterval)
+	}
+
+	return fmt.Errorf("timeout waiting for service %s to start", serviceName)
 }
 
-// Stop stops a Windows service by name.
+// Stop stops a Windows service by name and waits until it's stopped.
 func Stop(serviceName string) error {
-	cmd := exec.Command("sc", "stop", serviceName)
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to stop service %s: %w", serviceName, err)
+	// Already stopped? Nothing to do
+	status, _ := Status(serviceName)
+	if status == StatusStopped {
+		return nil
 	}
-	return nil
+
+	cmd := exec.Command("sc", "stop", serviceName)
+	cmd.Run() // Ignore error, we'll check actual state
+
+	// Poll until stopped or timeout
+	deadline := time.Now().Add(stopTimeout)
+	for time.Now().Before(deadline) {
+		status, _ := Status(serviceName)
+		if status == StatusStopped {
+			return nil
+		}
+		time.Sleep(pollInterval)
+	}
+
+	return fmt.Errorf("timeout waiting for service %s to stop", serviceName)
 }
 
 // Restart restarts a Windows service by stopping and starting it.
@@ -37,12 +72,11 @@ func Restart(serviceName string) error {
 
 // IsActive checks if a Windows service is running.
 func IsActive(serviceName string) (bool, error) {
-	cmd := exec.Command("sc", "query", serviceName)
-	output, err := cmd.Output()
+	status, err := Status(serviceName)
 	if err != nil {
-		return false, fmt.Errorf("failed to query service %s: %w", serviceName, err)
+		return false, err
 	}
-	return strings.Contains(string(output), "RUNNING"), nil
+	return status == StatusRunning, nil
 }
 
 // Status returns the status of a Windows service.


### PR DESCRIPTION
## Summary
- Add `PreDownload` hook to dependency reconciliation so the agent stops `UTMStackUpdater` before downloading the new binary, fixing the Windows file-lock that blocked cross-updates.
- Promote `version_new.json` → `version.json` before restart and roll back both binary and version file on failure.
- Poll Windows service state during updates instead of fixed sleeps to avoid 1056/1062 race conditions..
