### PR TITLE
Update filters: GCP, Sophos XG, Windows

### DIFF
--- a/filters/google/gcp.yml
+++ b/filters/google/gcp.yml
@@ -1,7 +1,8 @@
-# GCP filter, version 2.1.2
-# 
+# GCP filter, version 2.2.0
+#
 # Documentations
 # 1- https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry
+# 2- https://cloud.google.com/logging/docs/audit (protoPayload / AuditLog)
 
 pipeline:
   - dataTypes:
@@ -252,6 +253,75 @@ pipeline:
           to: log.resourceType
 
       # .......................................................................#
+      # Renaming protoPayload fields (Cloud Audit Logs — AuditLog message)
+      # .......................................................................#
+      # NOTE: log.protoPayload.@type is NOT renamed here. The engine treats
+      # paths containing '@' as complex and the rename plugin errors with
+      # "cannot delete value from a complex path". The whole log.protoPayload
+      # subtree is dropped in the final delete step, so the field is cleaned
+      # up implicitly. We use log.protoPayloadMethodName (always present in
+      # AuditLog) as the discriminator for protoPayload-derived actionResult.
+      - rename:
+          from:
+            - log.protoPayload.authenticationInfo.principalEmail
+          to: origin.user
+
+      - rename:
+          from:
+            - log.protoPayload.authenticationInfo.principalSubject
+          to: log.protoPayloadPrincipalSubject
+
+      - rename:
+          from:
+            - log.protoPayload.authenticationInfo.oauthInfo.oauthClientId
+          to: log.protoPayloadOauthClientId
+
+      - rename:
+          from:
+            - log.protoPayload.requestMetadata.callerIp
+          to: origin.ip
+
+      - rename:
+          from:
+            - log.protoPayload.requestMetadata.callerSuppliedUserAgent
+          to: log.httpUserAgent
+
+      - rename:
+          from:
+            - log.protoPayload.methodName
+          to: log.protoPayloadMethodName
+
+      - rename:
+          from:
+            - log.protoPayload.serviceName
+          to: log.protoPayloadServiceName
+
+      - rename:
+          from:
+            - log.protoPayload.resourceName
+          to: log.protoPayloadResourceName
+
+      - rename:
+          from:
+            - log.protoPayload.resourceLocation.currentLocations
+          to: log.protoPayloadResourceLocation
+
+      - rename:
+          from:
+            - log.protoPayload.authorizationInfo
+          to: log.protoPayloadAuthorizationInfo
+
+      - rename:
+          from:
+            - log.protoPayload.status.code
+          to: log.protoPayloadStatusCode
+
+      - rename:
+          from:
+            - log.protoPayload.status.message
+          to: log.protoPayloadStatusMessage
+
+      # .......................................................................#
       # Renaming operation field
       # .......................................................................#
       - rename:
@@ -301,6 +371,11 @@ pipeline:
       - cast:
           fields:
             - statusCode
+          to: int
+
+      - cast:
+          fields:
+            - log.protoPayloadStatusCode
           to: int
 
       # Adding severity field based on log.severity
@@ -382,6 +457,34 @@ pipeline:
             key: actionResult
             value: "denied"
           where: equals("log.jsonPayloadEnforcedEdgeSecurityPolicyOutcome", "DENY")
+
+      # Adding actionResult for Cloud Audit Logs (protoPayload):
+      # In GCP AuditLog, status.code follows google.rpc.Code — 0/absent = OK,
+      # any non-zero code = error. We only apply this when the event is an
+      # AuditLog (log.protoPayloadMethodName is always present in AuditLog;
+      # used as discriminator since log.protoPayload.@type can't be renamed
+      # due to the '@' character) so non-audit logs keep their existing
+      # actionResult derivation.
+      - add:
+          function: "string"
+          params:
+            key: actionResult
+            value: "success"
+          where: 'exists("log.protoPayloadMethodName") && !exists("log.protoPayloadStatusCode")'
+
+      - add:
+          function: "string"
+          params:
+            key: actionResult
+            value: "success"
+          where: 'exists("log.protoPayloadMethodName") && equals("log.protoPayloadStatusCode", 0)'
+
+      - add:
+          function: "string"
+          params:
+            key: actionResult
+            value: "failure"
+          where: 'exists("log.protoPayloadMethodName") && greaterThan("log.protoPayloadStatusCode", 0)'
 
       # Adding geolocation to origin.ip
       - dynamic:

--- a/filters/sophos/sophos_xg_firewall.yml
+++ b/filters/sophos/sophos_xg_firewall.yml
@@ -1,4 +1,4 @@
-# Sophos_XG filter, version 3.0.5
+# Sophos_XG filter, version 3.0.6
 # Supports SF 20.0 version log types
 # See manual: https://docs.sophos.com/nsg/sophos-firewall/20.0/pdf/sf-syslog-guide-20.0.pdf
 # and documentation https://docs.sophos.com/nsg/sophos-firewall/20.0/Help/en-us/webhelp/onlinehelp/AdministratorHelp/Logs/TroubleshootingLogs/LogFileDetails/index.html#https-ftp-waf
@@ -318,6 +318,7 @@ pipeline:
           from:
             - log.statuscode
           to: log.statusCode
+          where: exists("log.statuscode")
 
       - rename:
           from:
@@ -682,11 +683,27 @@ pipeline:
             - origin.bytesSent
           to: float
 
+      # Adding actionResult based on log.subtype value
+      - add:
+          function: 'string'
+          params:
+            key: actionResult
+            value: 'denied'
+          where: exists("log.subType") && equals("log.subType", "Denied")
+
+      - add:
+          function: 'string'
+          params:
+            key: actionResult
+            value: 'accepted'
+          where: exists("log.subType") && equals("log.subType", "Accepted") || equals("log.subType", "Allowed")
+
       # Renaming "log.statusCode" to "statusCode" to add it to the event structure
       - rename:
           from:
             - log.statusCode
           to: statusCode
+          where: exists("log.statusCode")
 
       # Adding actionResult
       # denied by default
@@ -695,13 +712,14 @@ pipeline:
           params:
             key: actionResult
             value: 'denied'
+          where: exists("statusCode")
 
       - add:
           function: 'string'
           params:
             key: actionResult
             value: 'accepted'
-          where: (greaterOrEqual("statusCode", 200) && lessOrEqual("statusCode", 299)) || (greaterOrEqual("statusCode", 300) && lessOrEqual("statusCode", 399) && greaterThan("origin.bytesReceived", 0))
+          where: exists("statusCode") && (greaterOrEqual("statusCode", 200) && lessOrEqual("statusCode", 299)) || (greaterOrEqual("statusCode", 300) && lessOrEqual("statusCode", 399) && greaterThan("origin.bytesReceived", 0))
 
       # Removing unused fields
       - delete:

--- a/filters/sophos/sophos_xg_firewall.yml
+++ b/filters/sophos/sophos_xg_firewall.yml
@@ -719,7 +719,7 @@ pipeline:
           params:
             key: actionResult
             value: 'accepted'
-          where: exists("statusCode") && (greaterOrEqual("statusCode", 200) && lessOrEqual("statusCode", 299)) || (greaterOrEqual("statusCode", 300) && lessOrEqual("statusCode", 399) && greaterThan("origin.bytesReceived", 0))
+          where: exists("statusCode") && ((greaterOrEqual("statusCode", 200) && lessOrEqual("statusCode", 299)) || (greaterOrEqual("statusCode", 300) && lessOrEqual("statusCode", 399) && greaterThan("origin.bytesReceived", 0)))
 
       # Removing unused fields
       - delete:

--- a/filters/windows/windows-events.yml
+++ b/filters/windows/windows-events.yml
@@ -47,6 +47,11 @@ pipeline:
 
       - rename:
           from:
+            - log.data.SubStatus
+          to: log.eventDataSubStatus
+
+      - rename:
+          from:
             - log.data.PrivilegeList
           to: log.eventDataPrivilegeList
 


### PR DESCRIPTION
Three independent filter updates, one commit per filter:

- **`feat(filters/gcp)`** — Add support for Cloud Audit Logs. Bumps GCP filter to 2.2.0. Maps `protoPayload` fields (user, IP, method, service, resource, status) and derives `actionResult` from the audit status. Without this, GCP audit events were not being normalized.
- **`fix(filters/sophos-xg)`** — Bumps Sophos XG filter to 3.0.6. Adds existence guards so the pipeline doesn't fail when `statusCode` is absent. Also derives `actionResult` from `log.subType` (Denied / Accepted / Allowed).
- **`chore(filters/windows)`** — Maps `log.data.SubStatus` to extend the existing event-data field set.
