### PR TITLE
Refactor rules: drop "now-" prefix from within field

### DIFF
--- a/rules/antivirus/bitdefender_gz/av_console_lateral_movement.yml
+++ b/rules/antivirus/bitdefender_gz/av_console_lateral_movement.yml
@@ -35,7 +35,7 @@ afterEvents:
       - field: log.hostId
         operator: filter_term
         value: '{{.log.hostId}}'
-    within: now-30m
+    within: 30m
     count: 10
 groupBy:
   - lastEvent.log.eventType

--- a/rules/antivirus/bitdefender_gz/av_policy_override.yml
+++ b/rules/antivirus/bitdefender_gz/av_policy_override.yml
@@ -36,7 +36,7 @@ afterEvents:
       - field: log.hostId
         operator: filter_term
         value: '{{.log.hostId}}'
-    within: now-1h
+    within: 1h
     count: 3
 groupBy:
   - lastEvent.log.eventType

--- a/rules/antivirus/bitdefender_gz/malware_outbreak_multiple_hosts.yml
+++ b/rules/antivirus/bitdefender_gz/malware_outbreak_multiple_hosts.yml
@@ -41,7 +41,7 @@ afterEvents:
       - field: log.eventType
         operator: filter_term
         value: "AntiMalware"
-    within: now-2h
+    within: 2h
     count: 10
 groupBy:
   - lastEvent.log.signatureID

--- a/rules/antivirus/bitdefender_gz/multiple_malware_from_single_source.yml
+++ b/rules/antivirus/bitdefender_gz/multiple_malware_from_single_source.yml
@@ -47,7 +47,7 @@ afterEvents:
       - field: log.eventType
         operator: filter_term
         value: "AntiMalware"
-    within: now-1h
+    within: 1h
     count: 5
 groupBy:
   - lastEvent.log.hostId

--- a/rules/antivirus/bitdefender_gz/network_threat_detection.yml
+++ b/rules/antivirus/bitdefender_gz/network_threat_detection.yml
@@ -39,7 +39,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-2h
+    within: 2h
     count: 5
     or:
       - indexPattern: v11-log-antivirus-bitdefender-gz-*
@@ -50,7 +50,7 @@ afterEvents:
           - field: log.eventType
             operator: filter_term
             value: 'network-sandboxing'
-        within: now-4h
+        within: 4h
         count: 3
 groupBy:
   - lastEvent.log.hostId

--- a/rules/antivirus/bitdefender_gz/ransomware_behavior_detection.yml
+++ b/rules/antivirus/bitdefender_gz/ransomware_behavior_detection.yml
@@ -37,7 +37,7 @@ afterEvents:
       - field: log.hostId
         operator: filter_term
         value: '{{.log.hostId}}'
-    within: now-10m
+    within: 10m
     count: 5
 groupBy:
   - lastEvent.log.hostId

--- a/rules/antivirus/bitdefender_gz/usb_malware_propagation.yml
+++ b/rules/antivirus/bitdefender_gz/usb_malware_propagation.yml
@@ -36,7 +36,7 @@ afterEvents:
       - field: log.hostId
         operator: filter_term
         value: '{{.log.hostId}}'
-    within: now-30m
+    within: 30m
     count: 5
 groupBy:
   - lastEvent.log.eventType

--- a/rules/antivirus/deceptive-bytes/advanced_threat_tactic_identification.yml
+++ b/rules/antivirus/deceptive-bytes/advanced_threat_tactic_identification.yml
@@ -43,7 +43,7 @@ afterEvents:
       - field: log.tacticName
         operator: filter_term
         value: '{{.log.tacticName}}'
-    within: now-15m
+    within: 15m
     count: 3
 groupBy:
   - lastEvent.log.tacticName

--- a/rules/antivirus/deceptive-bytes/data_theft_attempt_indicators.yml
+++ b/rules/antivirus/deceptive-bytes/data_theft_attempt_indicators.yml
@@ -38,7 +38,7 @@ afterEvents:
       - field: log.event_type
         operator: filter_term
         value: 'decoy_accessed'
-    within: now-2h
+    within: 2h
     count: 3
 groupBy:
   - lastEvent.log.decoy_file

--- a/rules/antivirus/deceptive-bytes/deception_token_access_patterns.yml
+++ b/rules/antivirus/deceptive-bytes/deception_token_access_patterns.yml
@@ -40,7 +40,7 @@ afterEvents:
       - field: log.eventType
         operator: filter_term
         value: 'token_access'
-    within: now-1h
+    within: 1h
     count: 3
 groupBy:
   - lastEvent.log.tokenId

--- a/rules/antivirus/deceptive-bytes/decoy_share_access_monitoring.yml
+++ b/rules/antivirus/deceptive-bytes/decoy_share_access_monitoring.yml
@@ -37,7 +37,7 @@ afterEvents:
       - field: log.resourceType
         operator: filter_term
         value: 'network_share'
-    within: now-30m
+    within: 30m
     count: 3
 deduplicateBy:
   - adversary.ip

--- a/rules/antivirus/deceptive-bytes/honey_table_query_detection.yml
+++ b/rules/antivirus/deceptive-bytes/honey_table_query_detection.yml
@@ -36,7 +36,7 @@ afterEvents:
       - field: log.eventType
         operator: filter_term
         value: decoy_access
-    within: now-1h
+    within: 1h
     count: 5
 groupBy:
   - lastEvent.log.tableName

--- a/rules/antivirus/deceptive-bytes/ransomware_behavior_patterns.yml
+++ b/rules/antivirus/deceptive-bytes/ransomware_behavior_patterns.yml
@@ -39,7 +39,7 @@ afterEvents:
       - field: log.source_ip
         operator: filter_term
         value: '{{.log.source_ip}}'
-    within: now-15m
+    within: 15m
     count: 10
 groupBy:
   - lastEvent.log.hostname

--- a/rules/antivirus/deceptive-bytes/zero_day_behavior_patterns.yml
+++ b/rules/antivirus/deceptive-bytes/zero_day_behavior_patterns.yml
@@ -46,7 +46,7 @@ afterEvents:
       - field: log.processName
         operator: filter_term
         value: '{{.log.processName}}'
-    within: now-30m
+    within: 30m
     count: 2
 groupBy:
   - lastEvent.log.exploitTechnique

--- a/rules/antivirus/esmc-eset/advanced_heuristic_detection_triggers.yml
+++ b/rules/antivirus/esmc-eset/advanced_heuristic_detection_triggers.yml
@@ -38,7 +38,7 @@ afterEvents:
       - field: log.headHostname
         operator: filter_term
         value: '{{.log.headHostname}}'
-    within: now-30m
+    within: 30m
     count: 3
 groupBy:
   - lastEvent.log.headHostname

--- a/rules/antivirus/esmc-eset/eset_console_abuse.yml
+++ b/rules/antivirus/esmc-eset/eset_console_abuse.yml
@@ -38,7 +38,7 @@ afterEvents:
       - field: log.headHostname
         operator: filter_term
         value: '{{.log.headHostname}}'
-    within: now-30m
+    within: 30m
     count: 10
 groupBy:
   - lastEvent.log.headHostname

--- a/rules/antivirus/esmc-eset/eset_quarantine_failures.yml
+++ b/rules/antivirus/esmc-eset/eset_quarantine_failures.yml
@@ -35,7 +35,7 @@ afterEvents:
       - field: log.headHostname
         operator: filter_term
         value: '{{.log.headHostname}}'
-    within: now-1h
+    within: 1h
     count: 5
 groupBy:
   - lastEvent.log.headHostname

--- a/rules/antivirus/kaspersky/data_exfiltration_attempts.yml
+++ b/rules/antivirus/kaspersky/data_exfiltration_attempts.yml
@@ -45,7 +45,7 @@ afterEvents:
       - field: log.cat
         operator: filter_term
         value: NetworkThreat
-    within: now-30m
+    within: 30m
     count: 5
 groupBy:
   - origin.ip

--- a/rules/antivirus/kaspersky/kaspersky_ransomware_behavior.yml
+++ b/rules/antivirus/kaspersky/kaspersky_ransomware_behavior.yml
@@ -36,5 +36,5 @@ afterEvents:
       - field: log.src
         operator: filter_term
         value: '{{.log.src}}'
-    within: now-10m
+    within: 10m
     count: 3

--- a/rules/antivirus/kaspersky/lateral_movement_indicators.yml
+++ b/rules/antivirus/kaspersky/lateral_movement_indicators.yml
@@ -41,5 +41,5 @@ afterEvents:
       - field: log.src
         operator: filter_term
         value: '{{.log.src}}'
-    within: now-2h
+    within: 2h
     count: 3

--- a/rules/antivirus/kaspersky/suspicious_network_activity.yml
+++ b/rules/antivirus/kaspersky/suspicious_network_activity.yml
@@ -46,7 +46,7 @@ afterEvents:
       - field: log.dstIP
         operator: filter_term
         value: '{{.log.dstIP}}'
-    within: now-30m
+    within: 30m
     count: 5
 groupBy:
   - target.ip

--- a/rules/cisco/asa/ips_signature_matches.yml
+++ b/rules/cisco/asa/ips_signature_matches.yml
@@ -35,7 +35,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-15m
+    within: 15m
     count: 3
 groupBy:
   - adversary.ip

--- a/rules/cisco/asa/multiple_failed_vpn_attempts.yml
+++ b/rules/cisco/asa/multiple_failed_vpn_attempts.yml
@@ -40,7 +40,7 @@ afterEvents:
       - field: log.messageId
         operator: filter_term
         value: '113015'
-    within: now-15m
+    within: 15m
     count: 10
     or:
       - indexPattern: v11-log-firewall-cisco-asa-*
@@ -51,7 +51,7 @@ afterEvents:
           - field: log.messageId
             operator: filter_term
             value: '113021'
-        within: now-15m
+        within: 15m
         count: 10
       - indexPattern: v11-log-firewall-cisco-asa-*
         with:
@@ -61,7 +61,7 @@ afterEvents:
           - field: log.messageId
             operator: filter_term
             value: '109034'
-        within: now-15m
+        within: 15m
         count: 10
       - indexPattern: v11-log-firewall-cisco-asa-*
         with:
@@ -71,7 +71,7 @@ afterEvents:
           - field: log.messageId
             operator: filter_term
             value: '611102'
-        within: now-15m
+        within: 15m
         count: 10
 groupBy:
   - adversary.ip

--- a/rules/cisco/cs_switch/arp_poisoning_detection.yml
+++ b/rules/cisco/cs_switch/arp_poisoning_detection.yml
@@ -36,7 +36,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-10m
+    within: 10m
     count: 5
 groupBy:
   - adversary.ip

--- a/rules/cisco/cs_switch/mac_address_spoofing.yml
+++ b/rules/cisco/cs_switch/mac_address_spoofing.yml
@@ -36,7 +36,7 @@ afterEvents:
       - field: origin.mac
         operator: filter_term
         value: '{{.origin.mac}}'
-    within: now-10m
+    within: 10m
     count: 3
 groupBy:
   - adversary.mac

--- a/rules/cisco/firepower/c2_nonstandard_port.yml
+++ b/rules/cisco/firepower/c2_nonstandard_port.yml
@@ -40,7 +40,7 @@ afterEvents:
       - field: target.ip
         operator: filter_term
         value: '{{.target.ip}}'
-    within: now-1h
+    within: 1h
     count: 5
 groupBy:
   - adversary.ip

--- a/rules/cisco/meraki/meraki_vpn_brute_force.yml
+++ b/rules/cisco/meraki/meraki_vpn_brute_force.yml
@@ -33,7 +33,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-15m
+    within: 15m
     count: 10
 groupBy:
   - adversary.ip

--- a/rules/cloud/aws/aws/aws_ecs_credential_theft.yml
+++ b/rules/cloud/aws/aws/aws_ecs_credential_theft.yml
@@ -38,7 +38,7 @@ afterEvents:
       - field: log.eventSource
         operator: filter_term
         value: 'ecs.amazonaws.com'
-    within: now-30m
+    within: 30m
     count: 5
 groupBy:
   - adversary.user

--- a/rules/cloud/aws/aws/aws_golden_saml_attack.yml
+++ b/rules/cloud/aws/aws/aws_golden_saml_attack.yml
@@ -34,7 +34,7 @@ afterEvents:
       - field: log.userIdentityAccountId
         operator: filter_term
         value: '{{.log.userIdentityAccountId}}'
-    within: now-24h
+    within: 24h
     count: 1
     or:
       - indexPattern: v11-log-aws-*
@@ -42,14 +42,14 @@ afterEvents:
           - field: log.eventName
             operator: filter_term
             value: 'UpdateSAMLProvider'
-        within: now-24h
+        within: 24h
         count: 1
       - indexPattern: v11-log-aws-*
         with:
           - field: log.eventName
             operator: filter_term
             value: 'CreateSAMLProvider'
-        within: now-24h
+        within: 24h
         count: 1
 groupBy:
   - adversary.user

--- a/rules/cloud/aws/aws/aws_securityhub_finding_evasion.yml
+++ b/rules/cloud/aws/aws/aws_securityhub_finding_evasion.yml
@@ -38,7 +38,7 @@ afterEvents:
       - field: log.eventSource
         operator: filter_term
         value: 'securityhub.amazonaws.com'
-    within: now-30m
+    within: 30m
     count: 5
 groupBy:
   - adversary.user

--- a/rules/cloud/aws/aws/aws_ssm_sendcommand_abuse.yml
+++ b/rules/cloud/aws/aws/aws_ssm_sendcommand_abuse.yml
@@ -36,7 +36,7 @@ afterEvents:
       - field: log.eventSource
         operator: filter_term
         value: 'ssm.amazonaws.com'
-    within: now-30m
+    within: 30m
     count: 5
 groupBy:
   - adversary.user

--- a/rules/cloud/aws/aws/aws_sso_suspicious_activities.yml
+++ b/rules/cloud/aws/aws/aws_sso_suspicious_activities.yml
@@ -38,7 +38,7 @@ afterEvents:
       - field: log.eventSource
         operator: filter_term
         value: 'sso.amazonaws.com'
-    within: now-30m
+    within: 30m
     count: 10
 groupBy:
   - lastEvent.log.sourceIPAddress

--- a/rules/cloud/aws/aws/cloudformation_stack_deletion.yml
+++ b/rules/cloud/aws/aws/cloudformation_stack_deletion.yml
@@ -34,7 +34,7 @@ afterEvents:
       - field: log.eventSource
         operator: filter_term
         value: 'cloudformation.amazonaws.com'
-    within: now-30m
+    within: 30m
     count: 5
 groupBy:
   - lastEvent.log.userIdentityAccountId

--- a/rules/cloud/aws/aws/console_login_impossible_travel.yml
+++ b/rules/cloud/aws/aws/console_login_impossible_travel.yml
@@ -41,7 +41,7 @@ afterEvents:
       - field: origin.geolocation.countryCode
         operator: must_not_term
         value: '{{.origin.geolocation.countryCode}}'
-    within: now-30m
+    within: 30m
     count: 1
 groupBy:
   - adversary.user

--- a/rules/cloud/aws/aws/cross_account_access_anomalies.yml
+++ b/rules/cloud/aws/aws/cross_account_access_anomalies.yml
@@ -40,7 +40,7 @@ afterEvents:
       - field: log.eventName
         operator: filter_term
         value: 'AssumeRole'
-    within: now-15m
+    within: 15m
     count: 15
 groupBy:
   - lastEvent.log.responseElementsAssumedRoleUserArn

--- a/rules/cloud/aws/aws/iam_backdoor_creation_attempts.yml
+++ b/rules/cloud/aws/aws/iam_backdoor_creation_attempts.yml
@@ -33,7 +33,7 @@ afterEvents:
       - field: log.eventSource
         operator: filter_term
         value: 'iam.amazonaws.com'
-    within: now-30m
+    within: 30m
     count: 3
 groupBy:
   - lastEvent.log.sourceIPAddress

--- a/rules/cloud/aws/aws/iam_privilege_escalation_paths.yml
+++ b/rules/cloud/aws/aws/iam_privilege_escalation_paths.yml
@@ -39,7 +39,7 @@ afterEvents:
       - field: log.eventSource
         operator: filter_term
         value: iam.amazonaws.com
-    within: now-30m
+    within: 30m
     count: 3
 groupBy:
   - adversary.user

--- a/rules/cloud/aws/aws/lambda_privilege_escalation.yml
+++ b/rules/cloud/aws/aws/lambda_privilege_escalation.yml
@@ -39,7 +39,7 @@ afterEvents:
       - field: log.eventName
         operator: filter_term
         value: AttachRolePolicy
-    within: now-1h
+    within: 1h
     count: 2
 groupBy:
   - lastEvent.log.requestParameters.roleArn

--- a/rules/cloud/aws/aws/mass_resource_deletion.yml
+++ b/rules/cloud/aws/aws/mass_resource_deletion.yml
@@ -32,7 +32,7 @@ afterEvents:
       - field: log.userIdentity.arn
         operator: filter_term
         value: '{{.log.userIdentity.arn}}'
-    within: now-10m
+    within: 10m
     count: 15
 groupBy:
   - lastEvent.log.sourceIPAddress

--- a/rules/cloud/aws/aws/route53_dns_hijacking.yml
+++ b/rules/cloud/aws/aws/route53_dns_hijacking.yml
@@ -35,7 +35,7 @@ afterEvents:
       - field: log.eventName
         operator: filter_term
         value: 'ChangeResourceRecordSets'
-    within: now-30m
+    within: 30m
     count: 10
 groupBy:
   - lastEvent.log.sourceIPAddress

--- a/rules/cloud/aws/aws/s3_bulk_data_exfiltration.yml
+++ b/rules/cloud/aws/aws/s3_bulk_data_exfiltration.yml
@@ -38,7 +38,7 @@ afterEvents:
       - field: log.eventName
         operator: filter_term
         value: GetObject
-    within: now-15m
+    within: 15m
     count: 100
 groupBy:
   - adversary.user

--- a/rules/cloud/aws/aws/secrets_manager_suspicious_access.yml
+++ b/rules/cloud/aws/aws/secrets_manager_suspicious_access.yml
@@ -33,7 +33,7 @@ afterEvents:
       - field: log.eventName
         operator: filter_term
         value: GetSecretValue
-    within: now-10m
+    within: 10m
     count: 10
   - indexPattern: v11-log-aws-*
     with:
@@ -43,7 +43,7 @@ afterEvents:
       - field: log.eventName
         operator: filter_term
         value: BatchGetSecretValue
-    within: now-10m
+    within: 10m
     count: 5
 groupBy:
   - lastEvent.log.sourceIPAddress

--- a/rules/cloud/aws/aws/security_group_modifications.yml
+++ b/rules/cloud/aws/aws/security_group_modifications.yml
@@ -45,7 +45,7 @@ afterEvents:
       - field: log.eventSource
         operator: filter_term
         value: 'ec2.amazonaws.com'
-    within: now-30m
+    within: 30m
     count: 3
 groupBy:
   - lastEvent.log.sourceIPAddress

--- a/rules/cloud/aws/aws/ssm_session_abuse.yml
+++ b/rules/cloud/aws/aws/ssm_session_abuse.yml
@@ -38,7 +38,7 @@ afterEvents:
       - field: log.eventSource
         operator: filter_term
         value: ssm.amazonaws.com
-    within: now-30m
+    within: 30m
     count: 5
 groupBy:
   - adversary.user

--- a/rules/cloud/aws/aws/sts_token_abuse.yml
+++ b/rules/cloud/aws/aws/sts_token_abuse.yml
@@ -39,7 +39,7 @@ afterEvents:
       - field: log.sourceIPAddress
         operator: filter_term
         value: '{{.log.sourceIPAddress}}'
-    within: now-15m
+    within: 15m
     count: 20
 groupBy:
   - lastEvent.log.userIdentityArn

--- a/rules/cloud/aws/aws/unusual_api_call_patterns.yml
+++ b/rules/cloud/aws/aws/unusual_api_call_patterns.yml
@@ -42,7 +42,7 @@ afterEvents:
       - field: log.eventName
         operator: filter_match
         value: 'Describe List Get Generate'
-    within: now-10m
+    within: 10m
     count: 50
 groupBy:
   - lastEvent.log.sourceIPAddress

--- a/rules/cloud/aws/aws/vpc_flow_log_anomalies.yml
+++ b/rules/cloud/aws/aws/vpc_flow_log_anomalies.yml
@@ -43,7 +43,7 @@ afterEvents:
       - field: log.eventName
         operator: filter_term
         value: 'DeleteFlowLogs'
-    within: now-24h
+    within: 24h
     count: 2
 deduplicateBy:
   - lastEvent.log.sourceIPAddress

--- a/rules/cloud/aws/credential_access_aws_iam_assume_role_brute_force.yml
+++ b/rules/cloud/aws/credential_access_aws_iam_assume_role_brute_force.yml
@@ -28,7 +28,7 @@ afterEvents:
       - field: origin.user
         operator: filter_term
         value: '{{.origin.user}}'
-    within: now-15m
+    within: 15m
     count: 5
 groupBy:
   - adversary.ip

--- a/rules/cloud/aws/credential_access_root_console_failure_brute_force.yml
+++ b/rules/cloud/aws/credential_access_root_console_failure_brute_force.yml
@@ -26,7 +26,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-15m
+    within: 15m
     count: 5
 groupBy:
   - adversary.ip

--- a/rules/cloud/azure/aks_security_threats.yml
+++ b/rules/cloud/azure/aks_security_threats.yml
@@ -41,7 +41,7 @@ afterEvents:
       - field: log.operationName
         operator: filter_match
         value: 'Container'
-    within: now-30m
+    within: 30m
     count: 10
 groupBy:
   - lastEvent.log.operationName

--- a/rules/cloud/azure/app_registration_abuse.yml
+++ b/rules/cloud/azure/app_registration_abuse.yml
@@ -39,7 +39,7 @@ afterEvents:
       - field: log.categoryValue
         operator: filter_term
         value: Administrative
-    within: now-1h
+    within: 1h
     count: 3
 groupBy:
   - lastEvent.log.operationName

--- a/rules/cloud/azure/application_gateway_waf_alerts.yml
+++ b/rules/cloud/azure/application_gateway_waf_alerts.yml
@@ -34,7 +34,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-10m
+    within: 10m
     count: 5
 groupBy:
   - lastEvent.log.ruleId

--- a/rules/cloud/azure/azure_ad_password_spray.yml
+++ b/rules/cloud/azure/azure_ad_password_spray.yml
@@ -40,7 +40,7 @@ afterEvents:
       - field: log.properties.status.errorCode
         operator: filter_match
         value: '5005'
-    within: now-15m
+    within: 15m
     count: 15
 groupBy:
   - lastEvent.log.operationName

--- a/rules/cloud/azure/azure_bulk_role_changes.yml
+++ b/rules/cloud/azure/azure_bulk_role_changes.yml
@@ -32,7 +32,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-30m
+    within: 30m
     count: 10
 groupBy:
   - adversary.ip

--- a/rules/cloud/azure/azure_kubernetes_secret_access.yml
+++ b/rules/cloud/azure/azure_kubernetes_secret_access.yml
@@ -33,7 +33,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-30m
+    within: 30m
     count: 5
 groupBy:
   - lastEvent.log.resourceId

--- a/rules/cloud/azure/azure_laps_credential_dump.yml
+++ b/rules/cloud/azure/azure_laps_credential_dump.yml
@@ -32,7 +32,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-1h
+    within: 1h
     count: 3
 groupBy:
   - adversary.ip

--- a/rules/cloud/azure/azure_ropc_authentication.yml
+++ b/rules/cloud/azure/azure_ropc_authentication.yml
@@ -32,7 +32,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-1h
+    within: 1h
     count: 5
 groupBy:
   - adversary.ip

--- a/rules/cloud/azure/key_vault_access_spikes.yml
+++ b/rules/cloud/azure/key_vault_access_spikes.yml
@@ -35,7 +35,7 @@ afterEvents:
       - field: log.category
         operator: filter_term
         value: 'AuditEvent'
-    within: now-10m
+    within: 10m
     count: 20
 groupBy:
   - lastEvent.log.resourceId

--- a/rules/cloud/azure/managed_identity_abuse.yml
+++ b/rules/cloud/azure/managed_identity_abuse.yml
@@ -36,7 +36,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-1h
+    within: 1h
     count: 5
 groupBy:
   - lastEvent.log.operationName

--- a/rules/cloud/azure/pim_role_activation_abuse.yml
+++ b/rules/cloud/azure/pim_role_activation_abuse.yml
@@ -39,7 +39,7 @@ afterEvents:
       - field: log.categoryValue
         operator: filter_term
         value: Administrative
-    within: now-4h
+    within: 4h
     count: 3
 groupBy:
   - lastEvent.log.operationName

--- a/rules/cloud/google/gcp_bigquery_exfiltration.yml
+++ b/rules/cloud/google/gcp_bigquery_exfiltration.yml
@@ -39,7 +39,7 @@ afterEvents:
       - field: log.protoPayload.serviceName
         operator: filter_term
         value: bigquery.googleapis.com
-    within: now-30m
+    within: 30m
     count: 10
 groupBy:
   - lastEvent.log.protoPayload.methodName

--- a/rules/cloud/google/gcp_custom_role_creation.yml
+++ b/rules/cloud/google/gcp_custom_role_creation.yml
@@ -35,7 +35,7 @@ afterEvents:
       - field: log.protoPayload.authenticationInfo.principalEmail
         operator: filter_term
         value: '{{.log.protoPayload.authenticationInfo.principalEmail}}'
-    within: now-1h
+    within: 1h
     count: 2
 groupBy:
   - lastEvent.log.protoPayload.methodName

--- a/rules/cloud/google/gcp_probable_password_guess.yml
+++ b/rules/cloud/google/gcp_probable_password_guess.yml
@@ -31,7 +31,7 @@ afterEvents:
       - field: log.protoPayload.authenticationInfo.principalEmail
         operator: filter_term
         value: "{{.log.protoPayload.authenticationInfo.principalEmail}}"
-    within: now-5m
+    within: 5m
     count: 5
 groupBy:
   - adversary.ip

--- a/rules/cloud/google/gcp_secret_manager_access.yml
+++ b/rules/cloud/google/gcp_secret_manager_access.yml
@@ -37,7 +37,7 @@ afterEvents:
       - field: log.protoPayload.methodName
         operator: filter_term
         value: AccessSecretVersion
-    within: now-15m
+    within: 15m
     count: 5
 groupBy:
   - lastEvent.log.protoPayload.methodName

--- a/rules/cloud/google/gcp_service_account_impersonation.yml
+++ b/rules/cloud/google/gcp_service_account_impersonation.yml
@@ -37,7 +37,7 @@ afterEvents:
       - field: log.protoPayload.authenticationInfo.principalEmail
         operator: filter_term
         value: '{{.log.protoPayload.authenticationInfo.principalEmail}}'
-    within: now-30m
+    within: 30m
     count: 10
 groupBy:
   - lastEvent.log.protoPayload.methodName

--- a/rules/cloud/google/service_account_key_creation_spikes.yml
+++ b/rules/cloud/google/service_account_key_creation_spikes.yml
@@ -33,7 +33,7 @@ afterEvents:
       - field: log.protoPayload.authenticationInfo.principalEmail
         operator: filter_term
         value: '{{.log.protoPayload.authenticationInfo.principalEmail}}'
-    within: now-1h
+    within: 1h
     count: 5
 groupBy:
   - lastEvent.log.protoPayload.authenticationInfo.principalEmail

--- a/rules/crowdstrike/multiple_authentication_failures_(possible_brute_force_attack).yml
+++ b/rules/crowdstrike/multiple_authentication_failures_(possible_brute_force_attack).yml
@@ -17,7 +17,7 @@ where: >
   exists("origin.ip")
 afterEvents:
   - indexPattern: v11-log-crowdstrike-*
-    within: now-15m
+    within: 15m
     count: 5
     with:
       - field: origin.ip

--- a/rules/fortinet/fortinet/admin_account_compromise.yml
+++ b/rules/fortinet/fortinet/admin_account_compromise.yml
@@ -43,7 +43,7 @@ afterEvents:
       - field: log.user
         operator: filter_term
         value: '{{.log.user}}'
-    within: now-15m
+    within: 15m
     count: 5
 groupBy:
   - adversary.ip

--- a/rules/fortinet/fortinet/antivirus_outbreak_detection.yml
+++ b/rules/fortinet/fortinet/antivirus_outbreak_detection.yml
@@ -42,7 +42,7 @@ afterEvents:
       - field: action
         operator: filter_term
         value: blocked
-    within: now-1h
+    within: 1h
     count: 5
 groupBy:
   - adversary.ip

--- a/rules/fortinet/fortinet/dlp_data_exfiltration.yml
+++ b/rules/fortinet/fortinet/dlp_data_exfiltration.yml
@@ -39,7 +39,7 @@ afterEvents:
       - field: log.subtype
         operator: filter_term
         value: 'dlp'
-    within: now-1h
+    within: 1h
     count: 3
 groupBy:
   - lastEvent.log.dlp_profile

--- a/rules/fortinet/fortinet/fortigate_vpn_brute_force.yml
+++ b/rules/fortinet/fortinet/fortigate_vpn_brute_force.yml
@@ -35,7 +35,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-15m
+    within: 15m
     count: 10
 groupBy:
   - adversary.ip

--- a/rules/fortinet/fortinet/ips_critical_severity_events.yml
+++ b/rules/fortinet/fortinet/ips_critical_severity_events.yml
@@ -31,7 +31,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-15m
+    within: 15m
     count: 3
 groupBy:
   - adversary.ip

--- a/rules/fortinet/fortiweb/authentication_bypass_attempts.yml
+++ b/rules/fortinet/fortiweb/authentication_bypass_attempts.yml
@@ -44,7 +44,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-15m
+    within: 15m
     count: 3
 groupBy:
   - adversary.ip

--- a/rules/fortinet/fortiweb/file_upload_security_violations.yml
+++ b/rules/fortinet/fortiweb/file_upload_security_violations.yml
@@ -43,7 +43,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-30m
+    within: 30m
     count: 3
 groupBy:
   - adversary.ip

--- a/rules/fortinet/fortiweb/fortiweb_sqli_detection.yml
+++ b/rules/fortinet/fortiweb/fortiweb_sqli_detection.yml
@@ -34,7 +34,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-15m
+    within: 15m
     count: 5
 groupBy:
   - adversary.ip

--- a/rules/fortinet/fortiweb/fortiweb_ssrf_detection.yml
+++ b/rules/fortinet/fortiweb/fortiweb_ssrf_detection.yml
@@ -34,7 +34,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-15m
+    within: 15m
     count: 3
 groupBy:
   - adversary.ip

--- a/rules/fortinet/fortiweb/owasp_top10_violations.yml
+++ b/rules/fortinet/fortiweb/owasp_top10_violations.yml
@@ -35,7 +35,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-15m
+    within: 15m
     count: 5
 groupBy:
   - adversary.ip

--- a/rules/fortinet/fortiweb/web_application_attacks_detection.yml
+++ b/rules/fortinet/fortiweb/web_application_attacks_detection.yml
@@ -50,7 +50,7 @@ afterEvents:
       - field: action
         operator: filter_term
         value: 'deny'
-    within: now-15m
+    within: 15m
     count: 3
 groupBy:
   - adversary.ip

--- a/rules/generic/generic/cross_source_lateral_movement.yml
+++ b/rules/generic/generic/cross_source_lateral_movement.yml
@@ -50,7 +50,7 @@ afterEvents:
       - field: log.message
         operator: filter_match
         value: 'remote login OR authenticated OR session opened'
-    within: now-30m
+    within: 30m
     count: 5
 groupBy:
   - adversary.ip

--- a/rules/github/action_secret_access.yml
+++ b/rules/github/action_secret_access.yml
@@ -37,7 +37,7 @@ afterEvents:
       - field: log.action
         operator: filter_match
         value: secret
-    within: now-1h
+    within: 1h
     count: 3
 groupBy:
   - lastEvent.log.action

--- a/rules/github/codeowners_modification.yml
+++ b/rules/github/codeowners_modification.yml
@@ -38,7 +38,7 @@ afterEvents:
       - field: log.senderLogin
         operator: filter_term
         value: '{{.log.senderLogin}}'
-    within: now-24h
+    within: 24h
     count: 2
 groupBy:
   - lastEvent.log.repositoryName

--- a/rules/github/dependabot_config_poisoning.yml
+++ b/rules/github/dependabot_config_poisoning.yml
@@ -38,7 +38,7 @@ afterEvents:
       - field: log.senderLogin
         operator: filter_term
         value: '{{.log.senderLogin}}'
-    within: now-24h
+    within: 24h
     count: 2
 groupBy:
   - lastEvent.log.repositoryName

--- a/rules/github/mass_repository_cloning.yml
+++ b/rules/github/mass_repository_cloning.yml
@@ -40,7 +40,7 @@ afterEvents:
       - field: log.action
         operator: filter_match
         value: 'clone fetch'
-    within: now-30m
+    within: 30m
     count: 10
 groupBy:
   - lastEvent.log.senderLogin

--- a/rules/ibm/ibm_aix/aix_hmc_access.yml
+++ b/rules/ibm/ibm_aix/aix_hmc_access.yml
@@ -46,7 +46,7 @@ afterEvents:
       - field: origin.host
         operator: filter_term
         value: '{{.origin.host}}'
-    within: now-30m
+    within: 30m
     count: 3
 groupBy:
   - adversary.host

--- a/rules/ibm/ibm_aix/aix_nim_abuse.yml
+++ b/rules/ibm/ibm_aix/aix_nim_abuse.yml
@@ -43,7 +43,7 @@ afterEvents:
       - field: origin.host
         operator: filter_term
         value: '{{.origin.host}}'
-    within: now-30m
+    within: 30m
     count: 3
 groupBy:
   - adversary.host

--- a/rules/ibm/ibm_as_400/as400_ifs_access.yml
+++ b/rules/ibm/ibm_as_400/as400_ifs_access.yml
@@ -47,7 +47,7 @@ afterEvents:
       - field: log.message
         operator: filter_match
         value: 'IFS OR CPYFRMSTMF OR CPYTOSTMF OR NetServer'
-    within: now-15m
+    within: 15m
     count: 10
 groupBy:
   - adversary.host

--- a/rules/ibm/ibm_as_400/as400_library_list_manipulation.yml
+++ b/rules/ibm/ibm_as_400/as400_library_list_manipulation.yml
@@ -43,7 +43,7 @@ afterEvents:
       - field: origin.user
         operator: filter_term
         value: '{{.origin.user}}'
-    within: now-15m
+    within: 15m
     count: 3
 groupBy:
   - adversary.host

--- a/rules/ibm/ibm_as_400/as400_remote_command.yml
+++ b/rules/ibm/ibm_as_400/as400_remote_command.yml
@@ -40,7 +40,7 @@ afterEvents:
       - field: origin.user
         operator: filter_term
         value: '{{.origin.user}}'
-    within: now-30m
+    within: 30m
     count: 3
 groupBy:
   - adversary.host

--- a/rules/ibm/ibm_as_400/as400_sql_injection.yml
+++ b/rules/ibm/ibm_as_400/as400_sql_injection.yml
@@ -45,7 +45,7 @@ afterEvents:
       - field: log.message
         operator: filter_match
         value: 'SQL error OR syntax error OR UNION SELECT OR DROP'
-    within: now-15m
+    within: 15m
     count: 5
 groupBy:
   - adversary.host

--- a/rules/json/json-input/deserialization_attacks.yml
+++ b/rules/json/json-input/deserialization_attacks.yml
@@ -42,7 +42,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-10m
+    within: 10m
     count: 3
 groupBy:
   - adversary.ip

--- a/rules/json/json-input/graphql_abuse.yml
+++ b/rules/json/json-input/graphql_abuse.yml
@@ -37,7 +37,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-15m
+    within: 15m
     count: 5
 groupBy:
   - adversary.ip

--- a/rules/json/json-input/json_injection_attempts.yml
+++ b/rules/json/json-input/json_injection_attempts.yml
@@ -38,7 +38,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-10m
+    within: 10m
     count: 3
 groupBy:
   - adversary.ip

--- a/rules/json/json-input/mass_assignment_attack.yml
+++ b/rules/json/json-input/mass_assignment_attack.yml
@@ -38,7 +38,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-10m
+    within: 10m
     count: 3
 groupBy:
   - adversary.ip

--- a/rules/json/json-input/nosql_injection_json.yml
+++ b/rules/json/json-input/nosql_injection_json.yml
@@ -42,7 +42,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-10m
+    within: 10m
     count: 3
 groupBy:
   - adversary.ip

--- a/rules/json/json-input/prototype_pollution_attempts.yml
+++ b/rules/json/json-input/prototype_pollution_attempts.yml
@@ -34,7 +34,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-10m
+    within: 10m
     count: 3
 groupBy:
   - adversary.host

--- a/rules/linux/bruteforce_attack.yml
+++ b/rules/linux/bruteforce_attack.yml
@@ -28,7 +28,7 @@ afterEvents:
       - field: log.message
         operator: filter_match
         value: 'Failed password'
-    within: now-15m
+    within: 15m
     count: 10
     or:
       - indexPattern: v11-log-linux-*
@@ -42,7 +42,7 @@ afterEvents:
           - field: log.message
             operator: filter_match
             value: 'authentication failure'
-        within: now-15m
+        within: 15m
         count: 10
 groupBy:
   - origin.ip

--- a/rules/linux/rhel_family/rhel_kernel_exploits.yml
+++ b/rules/linux/rhel_family/rhel_kernel_exploits.yml
@@ -33,7 +33,7 @@ afterEvents:
       - field: log.facility
         operator: filter_term
         value: 'kern'
-    within: now-5m
+    within: 5m
     count: 3
 groupBy:
   - origin.host

--- a/rules/macos/endpoint_security_bypass.yml
+++ b/rules/macos/endpoint_security_bypass.yml
@@ -41,7 +41,7 @@ afterEvents:
       - field: system.hostname
         operator: filter_term
         value: '{{.system.hostname}}'
-    within: now-15m
+    within: 15m
     count: 2
 groupBy:
   - lastEvent.log.process

--- a/rules/macos/macos_ransomware_indicators.yml
+++ b/rules/macos/macos_ransomware_indicators.yml
@@ -33,7 +33,7 @@ afterEvents:
       - field: origin.host
         operator: filter_term
         value: '{{.origin.host}}'
-    within: now-10m
+    within: 10m
     count: 50
 groupBy:
   - adversary.host

--- a/rules/mikrotik/mikrotik_fw/dns_cache_poisoning.yml
+++ b/rules/mikrotik/mikrotik_fw/dns_cache_poisoning.yml
@@ -38,7 +38,7 @@ afterEvents:
       - field: log.topics
         operator: filter_term
         value: 'dns'
-    within: now-5m
+    within: 5m
     count: 10
 groupBy:
   - adversary.ip

--- a/rules/mikrotik/mikrotik_fw/routeros_brute_force_attempts.yml
+++ b/rules/mikrotik/mikrotik_fw/routeros_brute_force_attempts.yml
@@ -34,7 +34,7 @@ afterEvents:
       - field: log.message
         operator: filter_match
         value: 'login failure'
-    within: now-15m
+    within: 15m
     count: 10
 groupBy:
   - adversary.ip

--- a/rules/mikrotik/mikrotik_fw/ssh_brute_force_attempts.yml
+++ b/rules/mikrotik/mikrotik_fw/ssh_brute_force_attempts.yml
@@ -39,7 +39,7 @@ afterEvents:
       - field: protocol
         operator: filter_term
         value: 'tcp'
-    within: now-15m
+    within: 15m
     count: 10
 groupBy:
   - adversary.ip

--- a/rules/netflow/beaconing_behavior_detection.yml
+++ b/rules/netflow/beaconing_behavior_detection.yml
@@ -41,7 +41,7 @@ afterEvents:
       - field: dataType
         operator: filter_term
         value: netflow
-    within: now-1h
+    within: 1h
     count: 30
 groupBy:
   - adversary.ip

--- a/rules/netflow/data_exfiltration_indicators.yml
+++ b/rules/netflow/data_exfiltration_indicators.yml
@@ -34,7 +34,7 @@ afterEvents:
       - field: dataType
         operator: filter_term
         value: netflow
-    within: now-1h
+    within: 1h
     count: 10
 groupBy:
   - adversary.ip

--- a/rules/netflow/ddos_traffic_patterns.yml
+++ b/rules/netflow/ddos_traffic_patterns.yml
@@ -34,7 +34,7 @@ afterEvents:
       - field: dataType
         operator: filter_term
         value: netflow
-    within: now-5m
+    within: 5m
     count: 100
 groupBy:
   - target.ip

--- a/rules/netflow/netflow_cryptomining_traffic.yml
+++ b/rules/netflow/netflow_cryptomining_traffic.yml
@@ -37,7 +37,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-30m
+    within: 30m
     count: 5
 groupBy:
   - adversary.ip

--- a/rules/netflow/netflow_doh_detection.yml
+++ b/rules/netflow/netflow_doh_detection.yml
@@ -43,7 +43,7 @@ afterEvents:
       - field: target.port
         operator: filter_term
         value: '443'
-    within: now-1h
+    within: 1h
     count: 20
 groupBy:
   - adversary.ip

--- a/rules/netflow/netflow_icmp_tunnel.yml
+++ b/rules/netflow/netflow_icmp_tunnel.yml
@@ -37,7 +37,7 @@ afterEvents:
       - field: target.ip
         operator: filter_term
         value: '{{.target.ip}}'
-    within: now-10m
+    within: 10m
     count: 20
 groupBy:
   - adversary.ip

--- a/rules/netflow/netflow_internal_scanning.yml
+++ b/rules/netflow/netflow_internal_scanning.yml
@@ -36,7 +36,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-5m
+    within: 5m
     count: 30
 deduplicateBy:
   - adversary.ip

--- a/rules/netflow/netflow_lateral_movement_smb_rdp.yml
+++ b/rules/netflow/netflow_lateral_movement_smb_rdp.yml
@@ -37,7 +37,7 @@ afterEvents:
       - field: target.port
         operator: filter_term
         value: '445'
-    within: now-10m
+    within: 10m
     count: 10
     or:
       - indexPattern: v11-log-netflow-*
@@ -48,7 +48,7 @@ afterEvents:
           - field: target.port
             operator: filter_term
             value: '3389'
-        within: now-10m
+        within: 10m
         count: 10
 groupBy:
   - adversary.ip

--- a/rules/netflow/netflow_vpn_unusual_destinations.yml
+++ b/rules/netflow/netflow_vpn_unusual_destinations.yml
@@ -39,7 +39,7 @@ afterEvents:
       - field: target.port
         operator: filter_term
         value: '{{.target.port}}'
-    within: now-1h
+    within: 1h
     count: 3
 groupBy:
   - adversary.ip

--- a/rules/netflow/port_scanning_patterns.yml
+++ b/rules/netflow/port_scanning_patterns.yml
@@ -39,7 +39,7 @@ afterEvents:
       - field: target.ip
         operator: filter_term
         value: '{{.target.ip}}'
-    within: now-2m
+    within: 2m
     count: 25
 deduplicateBy:
   - adversary.ip

--- a/rules/netflow/tor_usage_detection.yml
+++ b/rules/netflow/tor_usage_detection.yml
@@ -34,7 +34,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-1h
+    within: 1h
     count: 5
 groupBy:
   - adversary.ip

--- a/rules/nids/suricata/base64_dns_queries.yml
+++ b/rules/nids/suricata/base64_dns_queries.yml
@@ -38,7 +38,7 @@ afterEvents:
       - field: log.eventType
         operator: filter_term
         value: 'dns'
-    within: now-10m
+    within: 10m
     count: 5
 groupBy:
   - adversary.ip

--- a/rules/nids/suricata/base64_encoded_user_agent.yml
+++ b/rules/nids/suricata/base64_encoded_user_agent.yml
@@ -38,7 +38,7 @@ afterEvents:
       - field: log.eventType
         operator: filter_term
         value: 'http'
-    within: now-30m
+    within: 30m
     count: 3
 groupBy:
   - lastEvent.log.http.http_user_agent

--- a/rules/nids/suricata/cobalt_strike_dns_beacon.yml
+++ b/rules/nids/suricata/cobalt_strike_dns_beacon.yml
@@ -45,7 +45,7 @@ afterEvents:
       - field: log.eventType
         operator: filter_term
         value: 'dns'
-    within: now-15m
+    within: 15m
     count: 3
 groupBy:
   - lastEvent.log.dns.query

--- a/rules/nids/suricata/cobalt_strike_malleable_c2.yml
+++ b/rules/nids/suricata/cobalt_strike_malleable_c2.yml
@@ -51,7 +51,7 @@ afterEvents:
       - field: log.eventType
         operator: filter_term
         value: 'http'
-    within: now-30m
+    within: 30m
     count: 3
 groupBy:
   - adversary.ip

--- a/rules/nids/suricata/command_and_control_traffic.yml
+++ b/rules/nids/suricata/command_and_control_traffic.yml
@@ -47,7 +47,7 @@ afterEvents:
       - field: target.ip
         operator: filter_term
         value: '{{.target.ip}}'
-    within: now-1h
+    within: 1h
     count: 5
 groupBy:
   - adversary.ip

--- a/rules/nids/suricata/covert_channel_detection.yml
+++ b/rules/nids/suricata/covert_channel_detection.yml
@@ -42,7 +42,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-1h
+    within: 1h
     count: 10
 groupBy:
   - adversary.ip

--- a/rules/nids/suricata/data_exfiltration_patterns.yml
+++ b/rules/nids/suricata/data_exfiltration_patterns.yml
@@ -45,7 +45,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-30m
+    within: 30m
     count: 10
 groupBy:
   - adversary.ip

--- a/rules/nids/suricata/ddos_attack_patterns.yml
+++ b/rules/nids/suricata/ddos_attack_patterns.yml
@@ -50,7 +50,7 @@ afterEvents:
       - field: target.ip
         operator: filter_term
         value: '{{.target.ip}}'
-    within: now-5m
+    within: 5m
     count: 50
 groupBy:
   - adversary.ip

--- a/rules/nids/suricata/dns_tunneling_detection.yml
+++ b/rules/nids/suricata/dns_tunneling_detection.yml
@@ -39,7 +39,7 @@ afterEvents:
       - field: log.protocol
         operator: filter_term
         value: 'DNS'
-    within: now-5m
+    within: 5m
     count: 50
 groupBy:
   - adversary.ip

--- a/rules/nids/suricata/exploit_attempt_detection.yml
+++ b/rules/nids/suricata/exploit_attempt_detection.yml
@@ -38,7 +38,7 @@ afterEvents:
       - field: target.ip
         operator: filter_term
         value: '{{.target.ip}}'
-    within: now-15m
+    within: 15m
     count: 3
 groupBy:
   - lastEvent.log.alert.signature

--- a/rules/nids/suricata/hacktool_user_agents.yml
+++ b/rules/nids/suricata/hacktool_user_agents.yml
@@ -79,7 +79,7 @@ afterEvents:
       - field: log.eventType
         operator: filter_term
         value: 'http'
-    within: now-15m
+    within: 15m
     count: 10
 deduplicateBy:
   - adversary.ip

--- a/rules/nids/suricata/icmp_tunneling_detection.yml
+++ b/rules/nids/suricata/icmp_tunneling_detection.yml
@@ -39,7 +39,7 @@ afterEvents:
       - field: log.protocol
         operator: filter_term
         value: 'ICMP'
-    within: now-10m
+    within: 10m
     count: 100
 groupBy:
   - adversary.ip

--- a/rules/nids/suricata/lateral_movement_indicators.yml
+++ b/rules/nids/suricata/lateral_movement_indicators.yml
@@ -42,7 +42,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-10m
+    within: 10m
     count: 10
 groupBy:
   - adversary.ip

--- a/rules/nids/suricata/malware_callbacks.yml
+++ b/rules/nids/suricata/malware_callbacks.yml
@@ -36,7 +36,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-1h
+    within: 1h
     count: 10
 groupBy:
   - adversary.ip

--- a/rules/nids/suricata/nids_ssh_anomalies.yml
+++ b/rules/nids/suricata/nids_ssh_anomalies.yml
@@ -38,7 +38,7 @@ afterEvents:
       - field: target.ip
         operator: filter_term
         value: '{{.target.ip}}'
-    within: now-15m
+    within: 15m
     count: 10
 groupBy:
   - adversary.ip

--- a/rules/nids/suricata/nids_tls_certificate_anomalies.yml
+++ b/rules/nids/suricata/nids_tls_certificate_anomalies.yml
@@ -39,7 +39,7 @@ afterEvents:
       - field: target.ip
         operator: filter_term
         value: '{{.target.ip}}'
-    within: now-1h
+    within: 1h
     count: 10
 groupBy:
   - adversary.ip

--- a/rules/nids/suricata/nkn_blockchain_c2.yml
+++ b/rules/nids/suricata/nkn_blockchain_c2.yml
@@ -43,7 +43,7 @@ afterEvents:
       - field: log.eventType
         operator: filter_term
         value: 'dns'
-    within: now-15m
+    within: 15m
     count: 3
 groupBy:
   - lastEvent.log.dns.query

--- a/rules/nids/suricata/port_scan_detection.yml
+++ b/rules/nids/suricata/port_scan_detection.yml
@@ -48,7 +48,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-10m
+    within: 10m
     count: 50
   - indexPattern: v11-log-suricata-*
     with:
@@ -58,7 +58,7 @@ afterEvents:
       - field: target.ip
         operator: filter_term
         value: '{{.target.ip}}'
-    within: now-10m
+    within: 10m
     count: 20
 deduplicateBy:
   - adversary.ip

--- a/rules/nids/suricata/rclone_data_exfiltration.yml
+++ b/rules/nids/suricata/rclone_data_exfiltration.yml
@@ -42,7 +42,7 @@ afterEvents:
       - field: log.eventType
         operator: filter_term
         value: 'http'
-    within: now-30m
+    within: 30m
     count: 3
 groupBy:
   - adversary.ip

--- a/rules/nids/suricata/threat_intelligence_iocs.yml
+++ b/rules/nids/suricata/threat_intelligence_iocs.yml
@@ -37,7 +37,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-30m
+    within: 30m
     count: 3
 groupBy:
   - lastEvent.log.threat_type

--- a/rules/nids/suricata/tunneling_detection.yml
+++ b/rules/nids/suricata/tunneling_detection.yml
@@ -49,7 +49,7 @@ afterEvents:
       - field: target.port
         operator: filter_term
         value: '{{.target.port}}'
-    within: now-30m
+    within: 30m
     count: 5
 groupBy:
   - adversary.ip

--- a/rules/office365/anti_phishing_policy_bypasses.yml
+++ b/rules/office365/anti_phishing_policy_bypasses.yml
@@ -36,7 +36,7 @@ afterEvents:
       - field: log.Operation
         operator: filter_match
         value: 'AntiPhish'
-    within: now-4h
+    within: 4h
     count: 2
 groupBy:
   - lastEvent.log.Operation

--- a/rules/office365/azure_ad_integration_events.yml
+++ b/rules/office365/azure_ad_integration_events.yml
@@ -41,7 +41,7 @@ afterEvents:
       - field: log.Workload
         operator: filter_term
         value: 'AzureActiveDirectory'
-    within: now-15m
+    within: 15m
     count: 5
 groupBy:
   - adversary.ip

--- a/rules/office365/compliance_alert_patterns.yml
+++ b/rules/office365/compliance_alert_patterns.yml
@@ -50,7 +50,7 @@ afterEvents:
       - field: log.Workload
         operator: filter_term
         value: 'SecurityComplianceCenter'
-    within: now-2h
+    within: 2h
     count: 5
 groupBy:
   - lastEvent.action

--- a/rules/office365/conditional_access_bypasses.yml
+++ b/rules/office365/conditional_access_bypasses.yml
@@ -38,7 +38,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-30m
+    within: 30m
     count: 5
 groupBy:
   - adversary.ip

--- a/rules/office365/credential_access_microsoft_365_potential_password_spraying_attack.yml
+++ b/rules/office365/credential_access_microsoft_365_potential_password_spraying_attack.yml
@@ -23,7 +23,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-60s
+    within: 60s
     count: 5
 groupBy:
   - adversary.ip

--- a/rules/office365/ediscovery_abuse.yml
+++ b/rules/office365/ediscovery_abuse.yml
@@ -35,7 +35,7 @@ afterEvents:
       - field: origin.user
         operator: filter_term
         value: '{{.origin.user}}'
-    within: now-1h
+    within: 1h
     count: 5
 groupBy:
   - adversary.user

--- a/rules/office365/exchange_admin_changes.yml
+++ b/rules/office365/exchange_admin_changes.yml
@@ -33,7 +33,7 @@ afterEvents:
       - field: origin.user
         operator: filter_term
         value: '{{.origin.user}}'
-    within: now-1h
+    within: 1h
     count: 10
 groupBy:
   - lastEvent.action

--- a/rules/office365/external_sharing_violations.yml
+++ b/rules/office365/external_sharing_violations.yml
@@ -48,7 +48,7 @@ afterEvents:
       - field: origin.user
         operator: filter_term
         value: '{{.origin.user}}'
-    within: now-1h
+    within: 1h
     count: 5
 groupBy:
   - lastEvent.log.ObjectId

--- a/rules/office365/forms_sway_phishing.yml
+++ b/rules/office365/forms_sway_phishing.yml
@@ -42,7 +42,7 @@ afterEvents:
       - field: action
         operator: filter_match
         value: 'Form'
-    within: now-1h
+    within: 1h
     count: 3
 groupBy:
   - adversary.user

--- a/rules/office365/guest_user_invitation_spikes.yml
+++ b/rules/office365/guest_user_invitation_spikes.yml
@@ -42,7 +42,7 @@ afterEvents:
       - field: action
         operator: filter_term
         value: 'Invite external user'
-    within: now-1h
+    within: 1h
     count: 10
 groupBy:
   - adversary.user

--- a/rules/office365/information_barriers_violations.yml
+++ b/rules/office365/information_barriers_violations.yml
@@ -34,7 +34,7 @@ afterEvents:
       - field: log.PolicyType
         operator: filter_term
         value: 'InformationBarrier'
-    within: now-12h
+    within: 12h
     count: 3
 groupBy:
   - lastEvent.log.TargetUser

--- a/rules/office365/mail_flow_rule_changes.yml
+++ b/rules/office365/mail_flow_rule_changes.yml
@@ -36,7 +36,7 @@ afterEvents:
       - field: action
         operator: filter_match
         value: 'TransportRule'
-    within: now-1h
+    within: 1h
     count: 3
 groupBy:
   - lastEvent.action

--- a/rules/office365/mass_email_deletion.yml
+++ b/rules/office365/mass_email_deletion.yml
@@ -35,7 +35,7 @@ afterEvents:
       - field: action
         operator: filter_term
         value: 'HardDelete'
-    within: now-15m
+    within: 15m
     count: 100
     or:
       - indexPattern: v11-log-o365-*
@@ -46,7 +46,7 @@ afterEvents:
           - field: action
             operator: filter_term
             value: 'SoftDelete'
-        within: now-15m
+        within: 15m
         count: 100
 groupBy:
   - adversary.user

--- a/rules/office365/mfa_fatigue_push_spam.yml
+++ b/rules/office365/mfa_fatigue_push_spam.yml
@@ -40,7 +40,7 @@ afterEvents:
       - field: log.LogonError
         operator: filter_match
         value: 'Mfa'
-    within: now-15m
+    within: 15m
     count: 5
 groupBy:
   - adversary.ip

--- a/rules/office365/multi_geo_data_violations.yml
+++ b/rules/office365/multi_geo_data_violations.yml
@@ -40,7 +40,7 @@ afterEvents:
       - field: action
         operator: filter_term
         value: 'SiteGeoMoveScheduled'
-    within: now-24h
+    within: 24h
     count: 3
     or:
       - indexPattern: v11-log-o365-*
@@ -51,7 +51,7 @@ afterEvents:
           - field: action
             operator: filter_term
             value: 'AllowedDataLocationAdded'
-        within: now-24h
+        within: 24h
         count: 2
 groupBy:
   - adversary.ip

--- a/rules/office365/oauth_app_anomalies.yml
+++ b/rules/office365/oauth_app_anomalies.yml
@@ -35,7 +35,7 @@ afterEvents:
       - field: action
         operator: filter_term
         value: 'Consent to application'
-    within: now-1h
+    within: 1h
     count: 5
 groupBy:
   - lastEvent.log.appAccessContextClientAppId

--- a/rules/office365/onedrive_mass_file_access.yml
+++ b/rules/office365/onedrive_mass_file_access.yml
@@ -41,7 +41,7 @@ afterEvents:
       - field: log.Workload
         operator: filter_term
         value: 'OneDrive'
-    within: now-30m
+    within: 30m
     count: 67
     or:
       - indexPattern: v11-log-o365-*
@@ -55,7 +55,7 @@ afterEvents:
           - field: log.Workload
             operator: filter_term
             value: 'OneDrive'
-        within: now-30m
+        within: 30m
         count: 67
       - indexPattern: v11-log-o365-*
         with:
@@ -68,7 +68,7 @@ afterEvents:
           - field: log.Workload
             operator: filter_term
             value: 'OneDrive'
-        within: now-30m
+        within: 30m
         count: 67
 deduplicateBy:
   - adversary.user

--- a/rules/office365/possible_succesfull_password_guessing_o365.yml
+++ b/rules/office365/possible_succesfull_password_guessing_o365.yml
@@ -34,7 +34,7 @@ afterEvents:
         - field: log.clientIP
           operator: filter_term
           value: "{{.log.clientIP}}"
-      within: now-1m
+      within: 1m
       count: 10
 groupBy:
   - adversary.ip

--- a/rules/office365/power_apps_data_leaks.yml
+++ b/rules/office365/power_apps_data_leaks.yml
@@ -38,7 +38,7 @@ afterEvents:
       - field: action
         operator: filter_term
         value: 'CreateDataConnection'
-    within: now-12h
+    within: 12h
     count: 2
     or:
       - indexPattern: v11-log-o365-*
@@ -49,7 +49,7 @@ afterEvents:
           - field: action
             operator: filter_term
             value: 'UpdateDataConnection'
-        within: now-12h
+        within: 12h
         count: 2
       - indexPattern: v11-log-o365-*
         with:
@@ -59,7 +59,7 @@ afterEvents:
           - field: action
             operator: filter_term
             value: 'ExportData'
-        within: now-12h
+        within: 12h
         count: 3
 groupBy:
   - adversary.ip

--- a/rules/office365/power_automate_abuse.yml
+++ b/rules/office365/power_automate_abuse.yml
@@ -38,7 +38,7 @@ afterEvents:
       - field: log.Workload
         operator: filter_term
         value: 'PowerAutomate'
-    within: now-6h
+    within: 6h
     count: 10
 groupBy:
   - lastEvent.action

--- a/rules/office365/power_bi_data_export.yml
+++ b/rules/office365/power_bi_data_export.yml
@@ -37,7 +37,7 @@ afterEvents:
       - field: action
         operator: filter_match
         value: 'Export'
-    within: now-30m
+    within: 30m
     count: 5
 groupBy:
   - adversary.user

--- a/rules/office365/safe_links_click_patterns.yml
+++ b/rules/office365/safe_links_click_patterns.yml
@@ -34,7 +34,7 @@ afterEvents:
       - field: action
         operator: filter_term
         value: 'ClickedSafeLink'
-    within: now-30m
+    within: 30m
     count: 5
 groupBy:
   - adversary.user

--- a/rules/office365/sharepoint_mass_downloads.yml
+++ b/rules/office365/sharepoint_mass_downloads.yml
@@ -36,7 +36,7 @@ afterEvents:
       - field: action
         operator: filter_term
         value: 'FileDownloaded'
-    within: now-30m
+    within: 30m
     count: 100
 groupBy:
   - adversary.ip

--- a/rules/office365/teams_data_exfiltration.yml
+++ b/rules/office365/teams_data_exfiltration.yml
@@ -35,7 +35,7 @@ afterEvents:
       - field: log.Workload
         operator: filter_term
         value: 'MicrosoftTeams'
-    within: now-1h
+    within: 1h
     count: 20
 groupBy:
   - lastEvent.log.appAccessContextClientAppId

--- a/rules/office365/teams_external_user_abuse.yml
+++ b/rules/office365/teams_external_user_abuse.yml
@@ -38,7 +38,7 @@ afterEvents:
       - field: log.Parameters
         operator: filter_match
         value: '#EXT#'
-    within: now-1h
+    within: 1h
     count: 5
 groupBy:
   - adversary.ip

--- a/rules/paloalto/pa_firewall/panos_admin_brute_force.yml
+++ b/rules/paloalto/pa_firewall/panos_admin_brute_force.yml
@@ -36,7 +36,7 @@ afterEvents:
       - field: log.pa_type
         operator: filter_term
         value: 'SYSTEM'
-    within: now-15m
+    within: 15m
     count: 10
 groupBy:
   - adversary.ip

--- a/rules/paloalto/pa_firewall/panos_dns_security_alerts.yml
+++ b/rules/paloalto/pa_firewall/panos_dns_security_alerts.yml
@@ -39,7 +39,7 @@ afterEvents:
       - field: log.pa_subtype
         operator: filter_term
         value: 'dns'
-    within: now-30m
+    within: 30m
     count: 3
 groupBy:
   - adversary.ip

--- a/rules/paloalto/pa_firewall/panos_url_filtering_blocks.yml
+++ b/rules/paloalto/pa_firewall/panos_url_filtering_blocks.yml
@@ -38,7 +38,7 @@ afterEvents:
       - field: log.pa_subtype
         operator: filter_term
         value: 'url'
-    within: now-30m
+    within: 30m
     count: 5
 groupBy:
   - adversary.ip

--- a/rules/paloalto/pa_firewall/zero_day_exploit_prevention.yml
+++ b/rules/paloalto/pa_firewall/zero_day_exploit_prevention.yml
@@ -34,7 +34,7 @@ afterEvents:
       - field: log.pa_type
         operator: filter_term
         value: 'THREAT'
-    within: now-30m
+    within: 30m
     count: 2
 groupBy:
   - adversary.ip

--- a/rules/pfsense/dns_resolver_cache_poisoning.yml
+++ b/rules/pfsense/dns_resolver_cache_poisoning.yml
@@ -30,7 +30,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-5m
+    within: 5m
     count: 10
 groupBy:
   - lastEvent.log.query_name

--- a/rules/pfsense/pfsense_admin_brute_force.yml
+++ b/rules/pfsense/pfsense_admin_brute_force.yml
@@ -34,7 +34,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-15m
+    within: 15m
     count: 10
 groupBy:
   - adversary.ip

--- a/rules/pfsense/snort_suricata_ids_alerts.yml
+++ b/rules/pfsense/snort_suricata_ids_alerts.yml
@@ -34,7 +34,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-15m
+    within: 15m
     count: 3
 groupBy:
   - lastEvent.log.eventType

--- a/rules/sonicwall/sonicwall_firewall/anti_spyware_detection.yml
+++ b/rules/sonicwall/sonicwall_firewall/anti_spyware_detection.yml
@@ -37,7 +37,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-1h
+    within: 1h
     count: 3
 deduplicateBy:
   - adversary.ip

--- a/rules/sonicwall/sonicwall_firewall/botnet_detection.yml
+++ b/rules/sonicwall/sonicwall_firewall/botnet_detection.yml
@@ -31,7 +31,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-2h
+    within: 2h
     count: 10
 groupBy:
   - adversary.ip

--- a/rules/sonicwall/sonicwall_firewall/capture_atp_verdicts.yml
+++ b/rules/sonicwall/sonicwall_firewall/capture_atp_verdicts.yml
@@ -30,7 +30,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-1h
+    within: 1h
     count: 2
 groupBy:
   - adversary.host

--- a/rules/sonicwall/sonicwall_firewall/encrypted_threats_detection.yml
+++ b/rules/sonicwall/sonicwall_firewall/encrypted_threats_detection.yml
@@ -34,7 +34,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-30m
+    within: 30m
     count: 3
 groupBy:
   - adversary.ip

--- a/rules/sonicwall/sonicwall_firewall/gateway_antivirus_detection.yml
+++ b/rules/sonicwall/sonicwall_firewall/gateway_antivirus_detection.yml
@@ -37,7 +37,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-1h
+    within: 1h
     count: 3
 groupBy:
   - adversary.host

--- a/rules/sonicwall/sonicwall_firewall/intrusion_prevention_alert.yml
+++ b/rules/sonicwall/sonicwall_firewall/intrusion_prevention_alert.yml
@@ -37,7 +37,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-15m
+    within: 15m
     count: 3
 groupBy:
   - adversary.ip

--- a/rules/sonicwall/sonicwall_firewall/sonicwall_admin_auth_failures.yml
+++ b/rules/sonicwall/sonicwall_firewall/sonicwall_admin_auth_failures.yml
@@ -35,7 +35,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-15m
+    within: 15m
     count: 10
 groupBy:
   - adversary.ip

--- a/rules/sonicwall/sonicwall_firewall/sonicwall_vpn_failures.yml
+++ b/rules/sonicwall/sonicwall_firewall/sonicwall_vpn_failures.yml
@@ -35,7 +35,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-15m
+    within: 15m
     count: 10
 groupBy:
   - adversary.ip

--- a/rules/sophos/sophos_central/behavioral_analysis_alerts.yml
+++ b/rules/sophos/sophos_central/behavioral_analysis_alerts.yml
@@ -34,7 +34,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-30m
+    within: 30m
     count: 3
 groupBy:
   - lastEvent.log.processPath

--- a/rules/sophos/sophos_central/exploit_prevention_triggers.yml
+++ b/rules/sophos/sophos_central/exploit_prevention_triggers.yml
@@ -34,7 +34,7 @@ afterEvents:
       - field: log.endpointId
         operator: filter_term
         value: '{{.log.endpointId}}'
-    within: now-30m
+    within: 30m
     count: 2
 groupBy:
   - lastEvent.log.name

--- a/rules/sophos/sophos_central/managed_threat_response_alerts.yml
+++ b/rules/sophos/sophos_central/managed_threat_response_alerts.yml
@@ -35,7 +35,7 @@ afterEvents:
       - field: log.severity
         operator: filter_term
         value: 'critical'
-    within: now-1h
+    within: 1h
     count: 3
 groupBy:
   - adversary.host

--- a/rules/sophos/sophos_central/sophos_central_possible_brute_force_attack.yml
+++ b/rules/sophos/sophos_central/sophos_central_possible_brute_force_attack.yml
@@ -26,7 +26,7 @@ afterEvents:
         - field: log.ip
           operator: filter_term
           value: "{{.log.ip}}"
-      within: now-5m
+      within: 5m
       count: 10
 groupBy:
   - adversary.host

--- a/rules/sophos/sophos_central/sophos_central_potential_password_spraying_attack.yml
+++ b/rules/sophos/sophos_central/sophos_central_potential_password_spraying_attack.yml
@@ -26,7 +26,7 @@ afterEvents:
         - field: log.ip
           operator: filter_term
           value: "{{.log.ip}}"
-      within: now-1m
+      within: 1m
       count: 10
 groupBy:
   - adversary.host

--- a/rules/sophos/sophos_xg_firewall/advanced_threat_protection_alerts.yml
+++ b/rules/sophos/sophos_xg_firewall/advanced_threat_protection_alerts.yml
@@ -33,7 +33,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-30m
+    within: 30m
     count: 2
 groupBy:
   - adversary.ip

--- a/rules/sophos/sophos_xg_firewall/sophos_password_guessing_on_administrator_account.yml
+++ b/rules/sophos/sophos_xg_firewall/sophos_password_guessing_on_administrator_account.yml
@@ -29,7 +29,7 @@ afterEvents:
       - field: log.Id
         operator: filter_term
         value: '17913'
-    within: now-15m
+    within: 15m
     count: 10
 groupBy:
   - adversary.ip

--- a/rules/sophos/sophos_xg_firewall/sophos_xg_ips_signatures.yml
+++ b/rules/sophos/sophos_xg_firewall/sophos_xg_ips_signatures.yml
@@ -35,7 +35,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-15m
+    within: 15m
     count: 3
 groupBy:
   - adversary.ip

--- a/rules/sophos/sophos_xg_firewall/sophos_xg_vpn_auth_failures.yml
+++ b/rules/sophos/sophos_xg_firewall/sophos_xg_vpn_auth_failures.yml
@@ -35,7 +35,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-15m
+    within: 15m
     count: 10
 groupBy:
   - adversary.ip

--- a/rules/suricata/high_severity_suricata_alerts_were_detected.yml
+++ b/rules/suricata/high_severity_suricata_alerts_were_detected.yml
@@ -20,7 +20,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-15m
+    within: 15m
     count: 3
 groupBy:
   - adversary.ip

--- a/rules/suricata/medium_severity_suricata_alerts_were_detected.yml
+++ b/rules/suricata/medium_severity_suricata_alerts_were_detected.yml
@@ -20,7 +20,7 @@ afterEvents:
       - field: target.ip
         operator: filter_term
         value: '{{.target.ip}}'
-    within: now-15m
+    within: 15m
     count: 5
 deduplicateBy:
   - target.ip

--- a/rules/syslog/cef/syslog_source_impersonation.yml
+++ b/rules/syslog/cef/syslog_source_impersonation.yml
@@ -40,7 +40,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-15m
+    within: 15m
     count: 5
 groupBy:
   - lastEvent.log.deviceVendor

--- a/rules/syslog/cef/user_agent_anomalies.yml
+++ b/rules/syslog/cef/user_agent_anomalies.yml
@@ -43,7 +43,7 @@ afterEvents:
       - field: origin.ip
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-1h
+    within: 1h
     count: 10
 groupBy:
   - lastEvent.log.requestClientApplication

--- a/rules/vmware/vmware-esxi/vcenter_server_attacks.yml
+++ b/rules/vmware/vmware-esxi/vcenter_server_attacks.yml
@@ -45,7 +45,7 @@ afterEvents:
       - field: origin.hostname
         operator: filter_term
         value: '{{.origin.hostname}}'
-    within: now-30m
+    within: 30m
     count: 5
 groupBy:
   - adversary.host

--- a/rules/vmware/vmware-esxi/vmware_tools_vulnerabilities.yml
+++ b/rules/vmware/vmware-esxi/vmware_tools_vulnerabilities.yml
@@ -38,7 +38,7 @@ afterEvents:
       - field: origin.hostname
         operator: filter_term
         value: '{{.origin.hostname}}'
-    within: now-15m
+    within: 15m
     count: 5
 groupBy:
   - adversary.hostname

--- a/rules/vmware/vmware-esxi/vsphere_api_abuse.yml
+++ b/rules/vmware/vmware-esxi/vsphere_api_abuse.yml
@@ -46,7 +46,7 @@ afterEvents:
       - field: origin.hostname
         operator: filter_term
         value: '{{.origin.hostname}}'
-    within: now-5m
+    within: 5m
     count: 10
 groupBy:
   - lastEvent.log.eventInfo

--- a/rules/windows/adfs_authentication_anomalies.yml
+++ b/rules/windows/adfs_authentication_anomalies.yml
@@ -31,7 +31,7 @@ afterEvents:
       - field: origin.ip.keyword
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-10m
+    within: 10m
     count: 10
 groupBy:
   - origin.ip

--- a/rules/windows/asrep_roasting_detection.yml
+++ b/rules/windows/asrep_roasting_detection.yml
@@ -40,7 +40,7 @@ afterEvents:
       - field: origin.ip.keyword
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-15m
+    within: 15m
     count: 3
 groupBy:
   - origin.ip

--- a/rules/windows/golden_ticket_detection.yml
+++ b/rules/windows/golden_ticket_detection.yml
@@ -57,7 +57,7 @@ afterEvents:
       - field: origin.host
         operator: filter_term
         value: '{{.origin.host}}'
-    within: now-30m
+    within: 30m
     count: 3
 groupBy:
   - origin.host

--- a/rules/windows/kerberoasting_detection.yml
+++ b/rules/windows/kerberoasting_detection.yml
@@ -44,7 +44,7 @@ afterEvents:
       - field: origin.ip.keyword
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-15m
+    within: 15m
     count: 3
 groupBy:
   - origin.ip

--- a/rules/windows/ntds_extraction_attempts.yml
+++ b/rules/windows/ntds_extraction_attempts.yml
@@ -42,7 +42,7 @@ afterEvents:
       - field: origin.host
         operator: filter_term
         value: '{{.origin.host}}'
-    within: now-30m
+    within: 30m
     count: 2
 groupBy:
   - origin.host

--- a/rules/windows/ransom_multiple_file_deletion.yml
+++ b/rules/windows/ransom_multiple_file_deletion.yml
@@ -33,7 +33,7 @@ afterEvents:
         - field: target.user.keyword
           operator: filter_term
           value: "{{.target.user}}"
-      within: now-5m
+      within: 5m
       count: 50
 groupBy:
   - origin.ip

--- a/rules/windows/ransom_note_creation.yml
+++ b/rules/windows/ransom_note_creation.yml
@@ -25,7 +25,7 @@ afterEvents:
       - field: log.EventDataFileName.keyword
         operator: filter_term
         value: '{{.log.EventDataFileName}}'
-    within: now-60s
+    within: 60s
     count: 5
 groupBy:
   - origin.ip

--- a/rules/windows/ransom_unusual_file_extension.yml
+++ b/rules/windows/ransom_unusual_file_extension.yml
@@ -25,7 +25,7 @@ afterEvents:
         - field: target.user.keyword
           operator: filter_term
           value: "{{.target.user}}"
-      within: now-5m
+      within: 5m
       count: 20
 groupBy:
   - origin.ip

--- a/rules/windows/silver_ticket_detection.yml
+++ b/rules/windows/silver_ticket_detection.yml
@@ -44,7 +44,7 @@ afterEvents:
       - field: origin.ip.keyword
         operator: filter_term
         value: '{{.origin.ip}}'
-    within: now-15m
+    within: 15m
     count: 5
 groupBy:
   - origin.ip


### PR DESCRIPTION
## Changes

Across 199 correlation rules, the `within` field in the `afterEvents` block changes from the legacy `now-Xy` form to the supported `Xy` form:

- `within: now-5m` → `within: 5m`
- `within: now-30m` → `within: 30m`
- `within: now-1h` → `within: 1h`
- ...and so on for every duration in use (60s, 1m, 2m, 5m, 10m, 15m, 30m, 1h, 2h, 4h, 6h, 12h, 24h)

215 lines removed, 215 lines added — strictly symmetric. No changes to detection logic, conditions, deduplication, or any other field.

## Reasoning

The `Xy` form is the supported syntax for the `within` field. The legacy `now-Xy` form will be deprecated. This PR aligns the entire rule catalog with the format the engine actually supports.

## Reference

N/A — internal rule catalog fix, no linked issue.
