### PR TITLE
fix[frontend](alerts): properly handle update alerts errors

### DIFF
--- a/frontend/src/app/data-management/alert-management/shared/components/alert-action-select/alert-action-select.component.ts
+++ b/frontend/src/app/data-management/alert-management/shared/components/alert-action-select/alert-action-select.component.ts
@@ -164,7 +164,6 @@ export class AlertActionSelectComponent implements OnInit, OnDestroy {
     const alert = this.alert;
     this.changing = true;
     if (status === AlertStatusEnum.COMPLETED || status === AlertStatusEnum.COMPLETED_AS_FALSE_POSITIVE) {
-        console.log('status', status);
         const modalRef = this.modalService.open(AlertCompleteComponent, {centered: true});
         modalRef.componentInstance.alertsIDs = [alert.id];
         modalRef.componentInstance.canCreateRule = true;
@@ -184,6 +183,7 @@ export class AlertActionSelectComponent implements OnInit, OnDestroy {
             this.syncIncidentAlertStatus([this.alert.id], status);
           } else {
             this.changing = false;
+            this.utmToastService.showError('Error', 'An error occurred while changing the alert status. Please try again later.');
           }
         });
     } else {
@@ -192,6 +192,9 @@ export class AlertActionSelectComponent implements OnInit, OnDestroy {
         this.changing = false;
         this.alertUpdateHistoryBehavior.$refreshHistory.next(true);
         this.syncIncidentAlertStatus([this.alert.id], status);
+      }, () => {
+        this.changing = false;
+        this.utmToastService.showError('Error', 'An error occurred while changing the alert status. Please try again later.');
       });
     }
   }

--- a/frontend/src/app/data-management/alert-management/shared/components/alert-complete/alert-complete.component.ts
+++ b/frontend/src/app/data-management/alert-management/shared/components/alert-complete/alert-complete.component.ts
@@ -58,7 +58,10 @@ export class AlertCompleteComponent implements OnInit {
       this.statusChange.emit('success');
       this.activeModal.close();
       this.creating = false;
-    });
+    },_err=>{
+      this.creating = false;
+      this.statusChange.emit('failed');
+});
   }
 
   createRule() {


### PR DESCRIPTION
update alert status was failing on the opensearch side due to a lack of disk space but frontend wasnt handling that error properly