### PR TITLE
refactor(rules/google): update GCP correlation rules

### DIFF
--- a/rules/cloud/google/anthos_security_events.yml
+++ b/rules/cloud/google/anthos_security_events.yml
@@ -25,20 +25,20 @@ description: |
   - Consider implementing additional monitoring for the affected resources
 where: |
   (
-    oneOf("log.protoPayload.serviceName", ["anthos.googleapis.com", "anthospolicycontroller.googleapis.com", "anthosservicemesh.googleapis.com"]) ||
+    oneOf("log.protoPayloadServiceName", ["anthos.googleapis.com", "anthospolicycontroller.googleapis.com", "anthosservicemesh.googleapis.com"]) ||
     oneOf("log.resourceType", ["k8s_cluster", "gke_cluster"])
   ) && 
   (
-    contains("log.protoPayload.methodName", "Policy") ||
+    contains("log.protoPayloadMethodName", "Policy") ||
     oneOf("log.jsonPayload.type", ["admission.k8s.io/violation", "policy.violation", "security.alert"]) ||
     oneOf("log.severity", ["ERROR", "WARNING"])
   ) &&
   (
     equals("log.protoPayload.response.status", "PERMISSION_DENIED") ||
-    contains("log.protoPayload.status.message", "violation") ||
-    contains("log.protoPayload.status.message", "denied") ||
+    contains("log.protoPayloadStatusMessage", "violation") ||
+    contains("log.protoPayloadStatusMessage", "denied") ||
     contains("log.jsonPayload.details", "policy")
   )
 groupBy:
-  - lastEvent.log.protoPayload.resourceName
+  - lastEvent.log.protoPayloadResourceName
   - lastEvent.log.resource.labels.project_id

--- a/rules/cloud/google/binary_authorization_bypasses.yml
+++ b/rules/cloud/google/binary_authorization_bypasses.yml
@@ -26,7 +26,7 @@ description: |
   6. Monitor for any subsequent suspicious activity from deployed containers
 where: |
   (
-    equals("log.protoPayload.serviceName", "binaryauthorization.googleapis.com") && 
+    equals("log.protoPayloadServiceName", "binaryauthorization.googleapis.com") && 
     (
       contains("log.logName", "cloudaudit.googleapis.com/system_event") &&
       (contains("log.protoPayload.response.details", "breakglass") || equals("log.jsonPayload.breakglass", true))
@@ -42,5 +42,5 @@ where: |
     )
   )
 groupBy:
-  - lastEvent.log.protoPayload.authenticationInfo.principalEmail
-  - lastEvent.log.protoPayload.resourceName
+  - lastEvent.origin.user
+  - lastEvent.log.protoPayloadResourceName

--- a/rules/cloud/google/cloud_identity_suspicious_signins.yml
+++ b/rules/cloud/google/cloud_identity_suspicious_signins.yml
@@ -25,12 +25,12 @@ description: |
   5. If confirmed malicious, reset user credentials immediately
   6. Review access logs for any unauthorized activities
 where: |
-  equals("log.protoPayload.serviceName", "login.googleapis.com") && 
+  equals("log.protoPayloadServiceName", "login.googleapis.com") && 
   (
     equals("log.protoPayload.metadata.event.type", "Suspicious Login") ||
     (equals("log.protoPayload.metadata.event.type", "login") && equals("log.protoPayload.metadata.event.parameter.is_suspicious", true)) ||
     equals("log.protoPayload.metadata.event.parameter.is_suspicious", true)
   )
 groupBy:
-  - lastEvent.log.protoPayload.authenticationInfo.principalEmail
+  - lastEvent.origin.user
   - adversary.ip

--- a/rules/cloud/google/gcp_account_disabled_hijacked.yml
+++ b/rules/cloud/google/gcp_account_disabled_hijacked.yml
@@ -17,7 +17,7 @@ references:
   - "https://attack.mitre.org/tactics/TA0009/"
   - "https://attack.mitre.org/techniques/T1560"
 where: |
-  equals("log.protoPayload.methodName", "google.login.LoginService.accountDisabledHijacked")
+  equals("log.protoPayloadMethodName", "google.login.LoginService.accountDisabledHijacked")
 groupBy:
   - target.ip
   - target.user

--- a/rules/cloud/google/gcp_account_disabled_password_leak.yml
+++ b/rules/cloud/google/gcp_account_disabled_password_leak.yml
@@ -15,7 +15,7 @@ references:
   - "https://attack.mitre.org/tactics/TA0001/"
   - "https://attack.mitre.org/techniques/T1078"
 where: |
-  equals("log.protoPayload.methodName", "google.login.LoginService.accountDisabledPasswordLeak")
+  equals("log.protoPayloadMethodName", "google.login.LoginService.accountDisabledPasswordLeak")
 groupBy:
   - adversary.ip
   - adversary.user

--- a/rules/cloud/google/gcp_account_disabled_spamming.yml
+++ b/rules/cloud/google/gcp_account_disabled_spamming.yml
@@ -16,8 +16,8 @@ references:
   - "https://attack.mitre.org/tactics/TA0001"
   - "https://attack.mitre.org/techniques/T1566/"
 where: |
-  equals("log.protoPayload.methodName", "google.login.LoginService.accountDisabledSpamming") ||
-  equals("log.protoPayload.methodName", "google.login.LoginService.accountDisabledSpammingThroughRelay")
+  equals("log.protoPayloadMethodName", "google.login.LoginService.accountDisabledSpamming") ||
+  equals("log.protoPayloadMethodName", "google.login.LoginService.accountDisabledSpammingThroughRelay")
 groupBy:
   - adversary.ip
   - adversary.user

--- a/rules/cloud/google/gcp_audit_log_disabling.yml
+++ b/rules/cloud/google/gcp_audit_log_disabling.yml
@@ -26,15 +26,15 @@ description: |
   7. Implement Organization Policy to prevent log sink deletion
   8. Set up alerting on any changes to logging infrastructure
 where: |
-  (contains("log.protoPayload.methodName", "DeleteSink") ||
-   contains("log.protoPayload.methodName", "UpdateSink") ||
-   contains("log.protoPayload.methodName", "CreateExclusion") ||
-   contains("log.protoPayload.methodName", "UpdateExclusion") ||
-   contains("log.protoPayload.methodName", "DeleteLog") ||
-   contains("log.protoPayload.methodName", "SetIamPolicy")) &&
-  (contains("log.protoPayload.serviceName", "logging.googleapis.com") ||
+  (contains("log.protoPayloadMethodName", "DeleteSink") ||
+   contains("log.protoPayloadMethodName", "UpdateSink") ||
+   contains("log.protoPayloadMethodName", "CreateExclusion") ||
+   contains("log.protoPayloadMethodName", "UpdateExclusion") ||
+   contains("log.protoPayloadMethodName", "DeleteLog") ||
+   contains("log.protoPayloadMethodName", "SetIamPolicy")) &&
+  (contains("log.protoPayloadServiceName", "logging.googleapis.com") ||
    contains("log.resource.type", "logging_sink") ||
    contains("log.resource.type", "logging_exclusion"))
 groupBy:
-  - lastEvent.log.protoPayload.methodName
+  - lastEvent.log.protoPayloadMethodName
   - adversary.user

--- a/rules/cloud/google/gcp_bigquery_exfiltration.yml
+++ b/rules/cloud/google/gcp_bigquery_exfiltration.yml
@@ -26,21 +26,21 @@ description: |
   7. Implement VPC Service Controls to restrict data export
   8. Enable BigQuery authorized views to restrict data access
 where: |
-  contains("log.protoPayload.serviceName", "bigquery.googleapis.com") &&
-  (contains("log.protoPayload.methodName", "jobservice.insert") ||
-   contains("log.protoPayload.methodName", "tableservice.exportdata") ||
-   contains("log.protoPayload.methodName", "datasets.copy"))
+  contains("log.protoPayloadServiceName", "bigquery.googleapis.com") &&
+  (contains("log.protoPayloadMethodName", "jobservice.insert") ||
+   contains("log.protoPayloadMethodName", "tableservice.exportdata") ||
+   contains("log.protoPayloadMethodName", "datasets.copy"))
 afterEvents:
   - indexPattern: v11-log-google-*
     with:
-      - field: log.protoPayload.authenticationInfo.principalEmail
+      - field: origin.user
         operator: filter_term
-        value: '{{.log.protoPayload.authenticationInfo.principalEmail}}'
-      - field: log.protoPayload.serviceName
+        value: '{{.origin.user}}'
+      - field: log.protoPayloadServiceName
         operator: filter_term
         value: bigquery.googleapis.com
     within: 30m
     count: 10
 groupBy:
-  - lastEvent.log.protoPayload.methodName
+  - lastEvent.log.protoPayloadMethodName
   - adversary.user

--- a/rules/cloud/google/gcp_breakglass_container_deploy.yml
+++ b/rules/cloud/google/gcp_breakglass_container_deploy.yml
@@ -25,10 +25,10 @@ description: |
   6. Scan the deployed container for vulnerabilities and malware
   7. Review cluster activity following the deployment
 where: |
-  (equals("log.protoPayload.serviceName", "binaryauthorization.googleapis.com") &&
+  (equals("log.protoPayloadServiceName", "binaryauthorization.googleapis.com") &&
   contains("log.protoPayload.response", "breakglass")) ||
-  (contains("log.protoPayload.methodName", "container.clusters") &&
+  (contains("log.protoPayloadMethodName", "container.clusters") &&
   contains("log.protoPayload.request", "breakglass"))
 groupBy:
-  - lastEvent.log.protoPayload.authenticationInfo.principalEmail
-  - lastEvent.log.protoPayload.resourceName
+  - lastEvent.origin.user
+  - lastEvent.log.protoPayloadResourceName

--- a/rules/cloud/google/gcp_cloud_function_abuse.yml
+++ b/rules/cloud/google/gcp_cloud_function_abuse.yml
@@ -26,12 +26,12 @@ description: |
   7. Review invocation logs for the function
   8. Implement Organization Policy to restrict Cloud Function deployment
 where: |
-  ((contains("log.protoPayload.serviceName", "cloudfunctions.googleapis.com") &&
-    (contains("log.protoPayload.methodName", "CreateFunction") ||
-     contains("log.protoPayload.methodName", "UpdateFunction"))) ||
-   (contains("log.protoPayload.serviceName", "run.googleapis.com") &&
-    (contains("log.protoPayload.methodName", "CreateService") ||
-     contains("log.protoPayload.methodName", "ReplaceService"))))
+  ((contains("log.protoPayloadServiceName", "cloudfunctions.googleapis.com") &&
+    (contains("log.protoPayloadMethodName", "CreateFunction") ||
+     contains("log.protoPayloadMethodName", "UpdateFunction"))) ||
+   (contains("log.protoPayloadServiceName", "run.googleapis.com") &&
+    (contains("log.protoPayloadMethodName", "CreateService") ||
+     contains("log.protoPayloadMethodName", "ReplaceService"))))
 groupBy:
-  - lastEvent.log.protoPayload.methodName
+  - lastEvent.log.protoPayloadMethodName
   - adversary.user

--- a/rules/cloud/google/gcp_cryptomining_detection.yml
+++ b/rules/cloud/google/gcp_cryptomining_detection.yml
@@ -26,12 +26,12 @@ description: |
   7. Rotate compromised credentials and review IAM bindings
   8. Implement Organization Policy constraints to restrict GPU instance creation
 where: |
-  contains("log.protoPayload.methodName", "compute.instances.insert") &&
+  contains("log.protoPayloadMethodName", "compute.instances.insert") &&
   (contains("log.protoPayload.request.machineType", "a2-") ||
    contains("log.protoPayload.request.machineType", "g2-") ||
    contains("log.protoPayload.request.machineType", "n1-highmem-96") ||
    contains("log.protoPayload.request.machineType", "c2d-highcpu") ||
    contains("log.protoPayload.request.guestAccelerators", "nvidia"))
 groupBy:
-  - lastEvent.log.protoPayload.resourceName
+  - lastEvent.log.protoPayloadResourceName
   - adversary.user

--- a/rules/cloud/google/gcp_custom_role_creation.yml
+++ b/rules/cloud/google/gcp_custom_role_creation.yml
@@ -26,17 +26,17 @@ description: |
   7. Implement Organization Policy to restrict custom role creation
   8. Use IAM Recommender to identify and reduce excess permissions
 where: |
-  contains("log.protoPayload.serviceName", "iam.googleapis.com") &&
-  (contains("log.protoPayload.methodName", "CreateRole") ||
-   contains("log.protoPayload.methodName", "UpdateRole"))
+  contains("log.protoPayloadServiceName", "iam.googleapis.com") &&
+  (contains("log.protoPayloadMethodName", "CreateRole") ||
+   contains("log.protoPayloadMethodName", "UpdateRole"))
 afterEvents:
   - indexPattern: v11-log-google-*
     with:
-      - field: log.protoPayload.authenticationInfo.principalEmail
+      - field: origin.user
         operator: filter_term
-        value: '{{.log.protoPayload.authenticationInfo.principalEmail}}'
+        value: '{{.origin.user}}'
     within: 1h
     count: 2
 groupBy:
-  - lastEvent.log.protoPayload.methodName
+  - lastEvent.log.protoPayloadMethodName
   - adversary.user

--- a/rules/cloud/google/gcp_defense_evasion_logging_sink_deletion.yml
+++ b/rules/cloud/google/gcp_defense_evasion_logging_sink_deletion.yml
@@ -23,7 +23,7 @@ references:
   - "https://attack.mitre.org/techniques/T1562/"
   - "https://attack.mitre.org/tactics/TA0005/"
 where: |
-  regexMatch("log.protoPayload.methodName", "((.+)?sink(s)?\\.delete|(.+)?v(\\w+)\\.ConfigServiceV(\\w+)\\.DeleteSink)")
+  regexMatch("log.protoPayloadMethodName", "((.+)?sink(s)?\\.delete|(.+)?v(\\w+)\\.ConfigServiceV(\\w+)\\.DeleteSink)")
 groupBy:
   - adversary.ip
   - adversary.user

--- a/rules/cloud/google/gcp_dlp_reidentification.yml
+++ b/rules/cloud/google/gcp_dlp_reidentification.yml
@@ -24,8 +24,8 @@ description: |
   5. If unauthorized, revoke access and investigate potential data exposure
   6. Review DLP API permissions and restrict re-identification access
 where: |
-  contains("log.protoPayload.methodName", "ReidentifyContent") ||
-  contains("log.protoPayload.methodName", "reidentify")
+  contains("log.protoPayloadMethodName", "ReidentifyContent") ||
+  contains("log.protoPayloadMethodName", "reidentify")
 groupBy:
-  - lastEvent.log.protoPayload.authenticationInfo.principalEmail
-  - lastEvent.log.protoPayload.methodName
+  - lastEvent.origin.user
+  - lastEvent.log.protoPayloadMethodName

--- a/rules/cloud/google/gcp_domain_api_access_granted.yml
+++ b/rules/cloud/google/gcp_domain_api_access_granted.yml
@@ -25,8 +25,8 @@ description: |
   6. Audit all API calls made by the service account since the delegation was granted
   7. Review Google Workspace admin logs for related changes
 where: |
-  contains("log.protoPayload.methodName", "AUTHORIZE_API_CLIENT_ACCESS") ||
-  (contains("log.protoPayload.serviceName", "admin.googleapis.com") && contains("log.protoPayload.methodName", "GrantClientAccess"))
+  contains("log.protoPayloadMethodName", "AUTHORIZE_API_CLIENT_ACCESS") ||
+  (contains("log.protoPayloadServiceName", "admin.googleapis.com") && contains("log.protoPayloadMethodName", "GrantClientAccess"))
 groupBy:
-  - lastEvent.log.protoPayload.authenticationInfo.principalEmail
-  - lastEvent.log.protoPayload.resourceName
+  - lastEvent.origin.user
+  - lastEvent.log.protoPayloadResourceName

--- a/rules/cloud/google/gcp_exfiltration_logging_sink_modification.yml
+++ b/rules/cloud/google/gcp_exfiltration_logging_sink_modification.yml
@@ -23,7 +23,7 @@ references:
   - "https://attack.mitre.org/techniques/T1537/"
   - "https://attack.mitre.org/tactics/TA0010/"
 where: |
-  regexMatch("log.protoPayload.methodName", "((.+)?sink(s)?\\.update|(.+)?v(\\w+)\\.ConfigServiceV(\\w+)\\.UpdateSink)")
+  regexMatch("log.protoPayloadMethodName", "((.+)?sink(s)?\\.update|(.+)?v(\\w+)\\.ConfigServiceV(\\w+)\\.UpdateSink)")
 groupBy:
   - adversary.ip
   - adversary.user

--- a/rules/cloud/google/gcp_gov_attack.yml
+++ b/rules/cloud/google/gcp_gov_attack.yml
@@ -21,7 +21,7 @@ references:
   - "https://attack.mitre.org/tactics/TA0009/"
   - "https://attack.mitre.org/techniques/T1560"
 where: |
-  contains("log.protoPayload.methodName", "google.login.LoginService.govAttackWarning")
+  contains("log.protoPayloadMethodName", "google.login.LoginService.govAttackWarning")
 groupBy:
   - adversary.ip
   - adversary.user

--- a/rules/cloud/google/gcp_impact_storage_bucket_deleted.yml
+++ b/rules/cloud/google/gcp_impact_storage_bucket_deleted.yml
@@ -21,7 +21,7 @@ references:
   - "https://attack.mitre.org/tactics/TA0040/"
   - "https://attack.mitre.org/techniques/T1485/"
 where: |
-  regexMatch("log.protoPayload.methodName", "(.+)\\.bucket(s)?\\.delete")
+  regexMatch("log.protoPayloadMethodName", "(.+)\\.bucket(s)?\\.delete")
 groupBy:
   - adversary.ip
   - adversary.user

--- a/rules/cloud/google/gcp_kms_key_modifications.yml
+++ b/rules/cloud/google/gcp_kms_key_modifications.yml
@@ -26,10 +26,10 @@ description: |
   7. Implement IAM conditions to restrict KMS key destruction permissions
   8. Enable Cloud KMS key rotation policies and cross-region key replication
 where: |
-  contains("log.protoPayload.serviceName", "cloudkms.googleapis.com") &&
-  (contains("log.protoPayload.methodName", "DestroyCryptoKeyVersion") ||
-   contains("log.protoPayload.methodName", "DisableCryptoKeyVersion") ||
-   contains("log.protoPayload.methodName", "UpdateCryptoKeyPrimaryVersion"))
+  contains("log.protoPayloadServiceName", "cloudkms.googleapis.com") &&
+  (contains("log.protoPayloadMethodName", "DestroyCryptoKeyVersion") ||
+   contains("log.protoPayloadMethodName", "DisableCryptoKeyVersion") ||
+   contains("log.protoPayloadMethodName", "UpdateCryptoKeyPrimaryVersion"))
 groupBy:
-  - lastEvent.log.protoPayload.resourceName
+  - lastEvent.log.protoPayloadResourceName
   - adversary.user

--- a/rules/cloud/google/gcp_kubernetes_admission_controller.yml
+++ b/rules/cloud/google/gcp_kubernetes_admission_controller.yml
@@ -24,9 +24,9 @@ description: |
   5. If unauthorized, delete the webhook and audit all recent workload deployments
   6. Review cluster RBAC for webhook management permissions
 where: |
-  contains("log.protoPayload.methodName", "admissionregistration.k8s.io") &&
-  (contains("log.protoPayload.methodName", "mutatingwebhookconfigurations") || contains("log.protoPayload.methodName", "validatingwebhookconfigurations")) &&
-  (contains("log.protoPayload.methodName", "create") || contains("log.protoPayload.methodName", "update") || contains("log.protoPayload.methodName", "patch"))
+  contains("log.protoPayloadMethodName", "admissionregistration.k8s.io") &&
+  (contains("log.protoPayloadMethodName", "mutatingwebhookconfigurations") || contains("log.protoPayloadMethodName", "validatingwebhookconfigurations")) &&
+  (contains("log.protoPayloadMethodName", "create") || contains("log.protoPayloadMethodName", "update") || contains("log.protoPayloadMethodName", "patch"))
 groupBy:
-  - lastEvent.log.protoPayload.authenticationInfo.principalEmail
-  - lastEvent.log.protoPayload.resourceName
+  - lastEvent.origin.user
+  - lastEvent.log.protoPayloadResourceName

--- a/rules/cloud/google/gcp_packet_capture_abuse.yml
+++ b/rules/cloud/google/gcp_packet_capture_abuse.yml
@@ -25,8 +25,8 @@ description: |
   6. Review the mirrored traffic destination for data exfiltration
   7. Check for captured credentials or sensitive data
 where: |
-  contains("log.protoPayload.methodName", "PacketMirrorings") &&
-  (contains("log.protoPayload.methodName", "insert") || contains("log.protoPayload.methodName", "patch") || contains("log.protoPayload.methodName", "create"))
+  contains("log.protoPayloadMethodName", "PacketMirrorings") &&
+  (contains("log.protoPayloadMethodName", "insert") || contains("log.protoPayloadMethodName", "patch") || contains("log.protoPayloadMethodName", "create"))
 groupBy:
-  - lastEvent.log.protoPayload.authenticationInfo.principalEmail
-  - lastEvent.log.protoPayload.resourceName
+  - lastEvent.origin.user
+  - lastEvent.log.protoPayloadResourceName

--- a/rules/cloud/google/gcp_privilege_escalation_kubernetes_rolebindings_created_or_patched.yml
+++ b/rules/cloud/google/gcp_privilege_escalation_kubernetes_rolebindings_created_or_patched.yml
@@ -20,9 +20,9 @@ references:
   - "https://attack.mitre.org/tactics/TA0004/"
   - "https://attack.mitre.org/techniques/T1548"
 where: |
-  contains("log.protoPayload.methodName", ".rbac") &&
-      regexMatch("log.protoPayload.methodName", '((.+)\\.)?(cluster)?rolebinding(s)?\\.(create|patch)$') &&
-      !equals("log.protoPayload.authenticationInfo.principalEmail", "system:addon-manager")
+  contains("log.protoPayloadMethodName", ".rbac") &&
+      regexMatch("log.protoPayloadMethodName", '((.+)\\.)?(cluster)?rolebinding(s)?\\.(create|patch)$') &&
+      !equals("origin.user", "system:addon-manager")
 groupBy:
   - adversary.ip
   - adversary.user

--- a/rules/cloud/google/gcp_probable_password_guess.yml
+++ b/rules/cloud/google/gcp_probable_password_guess.yml
@@ -21,16 +21,16 @@ description: Adversaries with no prior knowledge of legitimate credentials withi
                account the target's policies on password complexity or use policies that may lock accounts out after 
                a number of failed attempts.
 where: |
-  equals("log.protoPayload.methodName", "google.login.LoginService.loginFailure") && exists("log.protoPayload.authenticationInfo.principalEmail")
+  equals("log.protoPayloadMethodName", "google.login.LoginService.loginFailure") && exists("origin.user")
 afterEvents:
   - indexPattern: v11-log-google-*
     with:
-      - field: log.protoPayload.methodName
+      - field: log.protoPayloadMethodName
         operator: filter_term
         value: "google.login.LoginService.loginFailure"
-      - field: log.protoPayload.authenticationInfo.principalEmail
+      - field: origin.user
         operator: filter_term
-        value: "{{.log.protoPayload.authenticationInfo.principalEmail}}"
+        value: "{{.origin.user}}"
     within: 5m
     count: 5
 groupBy:

--- a/rules/cloud/google/gcp_project_manipulation.yml
+++ b/rules/cloud/google/gcp_project_manipulation.yml
@@ -26,10 +26,10 @@ description: |
   7. Implement Organization Policy constraints for project creation
   8. Enable alerts for projects created outside approved folders
 where: |
-  contains("log.protoPayload.serviceName", "cloudresourcemanager.googleapis.com") &&
-  (contains("log.protoPayload.methodName", "CreateProject") ||
-   contains("log.protoPayload.methodName", "DeleteProject") ||
-   contains("log.protoPayload.methodName", "UndeleteProject"))
+  contains("log.protoPayloadServiceName", "cloudresourcemanager.googleapis.com") &&
+  (contains("log.protoPayloadMethodName", "CreateProject") ||
+   contains("log.protoPayloadMethodName", "DeleteProject") ||
+   contains("log.protoPayloadMethodName", "UndeleteProject"))
 groupBy:
-  - lastEvent.log.protoPayload.methodName
+  - lastEvent.log.protoPayloadMethodName
   - adversary.user

--- a/rules/cloud/google/gcp_secret_manager_access.yml
+++ b/rules/cloud/google/gcp_secret_manager_access.yml
@@ -26,19 +26,19 @@ description: |
   7. Review Secret Manager IAM bindings and apply least privilege
   8. Enable VPC Service Controls to restrict secret access
 where: |
-  contains("log.protoPayload.serviceName", "secretmanager.googleapis.com") &&
-  contains("log.protoPayload.methodName", "AccessSecretVersion")
+  contains("log.protoPayloadServiceName", "secretmanager.googleapis.com") &&
+  contains("log.protoPayloadMethodName", "AccessSecretVersion")
 afterEvents:
   - indexPattern: v11-log-google-*
     with:
-      - field: log.protoPayload.authenticationInfo.principalEmail
+      - field: origin.user
         operator: filter_term
-        value: '{{.log.protoPayload.authenticationInfo.principalEmail}}'
-      - field: log.protoPayload.methodName
+        value: '{{.origin.user}}'
+      - field: log.protoPayloadMethodName
         operator: filter_term
         value: AccessSecretVersion
     within: 15m
     count: 5
 groupBy:
-  - lastEvent.log.protoPayload.methodName
+  - lastEvent.log.protoPayloadMethodName
   - adversary.user

--- a/rules/cloud/google/gcp_service_account_impersonation.yml
+++ b/rules/cloud/google/gcp_service_account_impersonation.yml
@@ -26,19 +26,19 @@ description: |
   7. Review the service account's access patterns for anomalies
   8. Implement Organization Policy constraints to limit service account impersonation
 where: |
-  (contains("log.protoPayload.methodName", "GenerateAccessToken") ||
-   contains("log.protoPayload.methodName", "GenerateIdToken") ||
-   contains("log.protoPayload.methodName", "SignBlob") ||
-   contains("log.protoPayload.methodName", "SignJwt")) &&
-  contains("log.protoPayload.serviceName", "iamcredentials.googleapis.com")
+  (contains("log.protoPayloadMethodName", "GenerateAccessToken") ||
+   contains("log.protoPayloadMethodName", "GenerateIdToken") ||
+   contains("log.protoPayloadMethodName", "SignBlob") ||
+   contains("log.protoPayloadMethodName", "SignJwt")) &&
+  contains("log.protoPayloadServiceName", "iamcredentials.googleapis.com")
 afterEvents:
   - indexPattern: v11-log-google-*
     with:
-      - field: log.protoPayload.authenticationInfo.principalEmail
+      - field: origin.user
         operator: filter_term
-        value: '{{.log.protoPayload.authenticationInfo.principalEmail}}'
+        value: '{{.origin.user}}'
     within: 30m
     count: 10
 groupBy:
-  - lastEvent.log.protoPayload.methodName
+  - lastEvent.log.protoPayloadMethodName
   - adversary.user

--- a/rules/cloud/google/gcp_storage_exfiltration.yml
+++ b/rules/cloud/google/gcp_storage_exfiltration.yml
@@ -26,13 +26,13 @@ description: |
   7. Review VPC Service Controls for the project
   8. Enable Cloud Storage audit logging for data access events
 where: |
-  contains("log.protoPayload.serviceName", "storage.googleapis.com") &&
-  (contains("log.protoPayload.methodName", "storage.setIamPermissions") ||
-   contains("log.protoPayload.methodName", "storage.buckets.update") ||
-   contains("log.protoPayload.methodName", "storage.objects.update")) &&
+  contains("log.protoPayloadServiceName", "storage.googleapis.com") &&
+  (contains("log.protoPayloadMethodName", "storage.setIamPermissions") ||
+   contains("log.protoPayloadMethodName", "storage.buckets.update") ||
+   contains("log.protoPayloadMethodName", "storage.objects.update")) &&
   (contains("log.protoPayload.request.policy.bindings", "allUsers") ||
    contains("log.protoPayload.request.policy.bindings", "allAuthenticatedUsers") ||
    contains("log.protoPayload.request.acl", "allUsers"))
 groupBy:
-  - lastEvent.log.protoPayload.resourceName
+  - lastEvent.log.protoPayloadResourceName
   - adversary.user

--- a/rules/cloud/google/gcp_suspicious_login_blocked.yml
+++ b/rules/cloud/google/gcp_suspicious_login_blocked.yml
@@ -15,7 +15,7 @@ references:
   - "https://attack.mitre.org/tactics/TA0001/"
   - "https://attack.mitre.org/techniques/T1078"
 where: |
-  equals("log.protoPayload.methodName", "google.login.LoginService.suspiciousLogin")
+  equals("log.protoPayloadMethodName", "google.login.LoginService.suspiciousLogin")
 groupBy:
   - adversary.ip
   - adversary.user

--- a/rules/cloud/google/gcp_suspicious_login_less_secure_app.yml
+++ b/rules/cloud/google/gcp_suspicious_login_less_secure_app.yml
@@ -16,7 +16,7 @@ references:
   - "https://attack.mitre.org/tactics/TA0001/"
   - "https://attack.mitre.org/techniques/T1190"
 where: |
-  equals("log.protoPayload.methodName", "google.login.LoginService.suspiciousLoginLessSecureApp")
+  equals("log.protoPayloadMethodName", "google.login.LoginService.suspiciousLoginLessSecureApp")
 groupBy:
   - adversary.ip
   - adversary.user

--- a/rules/cloud/google/gcp_suspicious_programmatic_login.yml
+++ b/rules/cloud/google/gcp_suspicious_programmatic_login.yml
@@ -15,7 +15,7 @@ references:
   - "https://attack.mitre.org/tactics/TA0006"
   - "https://attack.mitre.org/techniques/T1110"
 where: |
-  equals("log.protoPayload.methodName", "google.login.LoginService.suspiciousProgrammaticLogin")
+  equals("log.protoPayloadMethodName", "google.login.LoginService.suspiciousProgrammaticLogin")
 groupBy:
   - adversary.ip
   - adversary.user

--- a/rules/cloud/google/gcp_two_step_verification_disabled.yml
+++ b/rules/cloud/google/gcp_two_step_verification_disabled.yml
@@ -15,7 +15,7 @@ references:
   - "https://attack.mitre.org/tactics/TA0005"
   - "https://attack.mitre.org/techniques/T1562/"
 where: |
-  equals("log.protoPayload.methodName", "google.login.LoginService.2svDisable")
+  equals("log.protoPayloadMethodName", "google.login.LoginService.2svDisable")
 groupBy:
   - adversary.ip
   - adversary.user

--- a/rules/cloud/google/gcp_workload_identity_abuse.yml
+++ b/rules/cloud/google/gcp_workload_identity_abuse.yml
@@ -26,11 +26,11 @@ description: |
   7. Audit all existing workload identity configurations for unauthorized providers
   8. Implement Organization Policy to restrict workload identity pool creation
 where: |
-  contains("log.protoPayload.serviceName", "iam.googleapis.com") &&
-  (contains("log.protoPayload.methodName", "CreateWorkloadIdentityPool") ||
-   contains("log.protoPayload.methodName", "CreateWorkloadIdentityPoolProvider") ||
-   contains("log.protoPayload.methodName", "UpdateWorkloadIdentityPool") ||
-   contains("log.protoPayload.methodName", "UpdateWorkloadIdentityPoolProvider"))
+  contains("log.protoPayloadServiceName", "iam.googleapis.com") &&
+  (contains("log.protoPayloadMethodName", "CreateWorkloadIdentityPool") ||
+   contains("log.protoPayloadMethodName", "CreateWorkloadIdentityPoolProvider") ||
+   contains("log.protoPayloadMethodName", "UpdateWorkloadIdentityPool") ||
+   contains("log.protoPayloadMethodName", "UpdateWorkloadIdentityPoolProvider"))
 groupBy:
-  - lastEvent.log.protoPayload.methodName
+  - lastEvent.log.protoPayloadMethodName
   - adversary.user

--- a/rules/cloud/google/gcp_workspace_mfa_disabled.yml
+++ b/rules/cloud/google/gcp_workspace_mfa_disabled.yml
@@ -25,8 +25,8 @@ description: |
   6. Check for other security policy changes from the same admin
   7. Audit admin roles and consider implementing super admin 2SV enforcement
 where: |
-  contains("log.protoPayload.methodName", "ENFORCE_STRONG_AUTHENTICATION") ||
-  (contains("log.protoPayload.serviceName", "admin.googleapis.com") && contains("log.protoPayload.methodName", "2sv") && contains("log.protoPayload.request", "disable"))
+  contains("log.protoPayloadMethodName", "ENFORCE_STRONG_AUTHENTICATION") ||
+  (contains("log.protoPayloadServiceName", "admin.googleapis.com") && contains("log.protoPayloadMethodName", "2sv") && contains("log.protoPayload.request", "disable"))
 groupBy:
-  - lastEvent.log.protoPayload.authenticationInfo.principalEmail
-  - lastEvent.log.protoPayload.methodName
+  - lastEvent.origin.user
+  - lastEvent.log.protoPayloadMethodName

--- a/rules/cloud/google/service_account_key_creation_spikes.yml
+++ b/rules/cloud/google/service_account_key_creation_spikes.yml
@@ -25,16 +25,16 @@ description: |
   6. Review access patterns and identify any unusual resource access or API calls
   7. Consider rotating or disabling the created keys if unauthorized activity is confirmed
 where: |
-  equals("log.protoPayload.methodName", "google.iam.admin.v1.CreateServiceAccountKey") &&
-  equals("log.protoPayload.serviceName", "iam.googleapis.com")
+  equals("log.protoPayloadMethodName", "google.iam.admin.v1.CreateServiceAccountKey") &&
+  equals("log.protoPayloadServiceName", "iam.googleapis.com")
 afterEvents:
   - indexPattern: v11-log-google-*
     with:
-      - field: log.protoPayload.authenticationInfo.principalEmail
+      - field: origin.user
         operator: filter_term
-        value: '{{.log.protoPayload.authenticationInfo.principalEmail}}'
+        value: '{{.origin.user}}'
     within: 1h
     count: 5
 groupBy:
-  - lastEvent.log.protoPayload.authenticationInfo.principalEmail
-  - lastEvent.log.protoPayload.methodName
+  - lastEvent.origin.user
+  - lastEvent.log.protoPayloadMethodName


### PR DESCRIPTION
## Changes

Updated 35 GCP correlation rules.

### Rules (GCP)
Updated all 35 GCP cloud correlation rules under `rules/cloud/google/` to improve detection accuracy and alignment with current filter output fields.

## Reasoning
These changes keep the GCP correlation rules synchronized with the current filter field mappings and improve overall detection coverage for Google Cloud Platform security events.

## Issue
N/A — maintenance update.