### PR TITLE
Add O365 rule: Admin Role Assignment

### DIFF
--- a/rules/office365/o365-admin-role-assignment.yml
+++ b/rules/office365/o365-admin-role-assignment.yml
@@ -1,0 +1,23 @@
+# Rule version v1.0.0
+
+name: O365 Admin Role Assignment
+description: |
+  Detects when an administrator assigns privileged roles, adds members to admin groups,
+  or grants delegated/app role permissions in Azure Active Directory. This activity can
+  indicate account compromise or insider threat where an attacker escalates privileges
+  to maintain persistence within the tenant.
+category: "Persistence"
+technique: "T1136 - Create Account"
+references:
+  - "https://attack.mitre.org/techniques/T1136/"
+dataTypes:
+  - o365
+adversary: origin
+impact:
+  confidentiality: 2
+  integrity: 3
+  availability: 0
+where: equals("log.Workload", "AzureActiveDirectory") && oneOf("action", ["Add member to group.", "Add delegated permission grant.", "Add app role assignment grant to user."])
+groupBy:
+  - adversary.user
+  - lastEvent.log.ObjectId


### PR DESCRIPTION

## Changes
Adds a new O365 correlation rule o365-admin-role-assignment.yml that detects when an administrator assigns privileged roles, adds members to admin groups, or grants delegated/app role permissions in Azure Active Directory.

## Reasoning
Privilege escalation via role/permission grants in Azure AD is a high-fidelity persistence technique. Attackers who compromise an account with directory write permissions commonly grant themselves (or a backdoor account) elevated roles or OAuth app permissions to maintain access even if the initial entry vector is closed. Detecting these grants in near real time lets SOC teams catch persistence setup before it is exercised.

## Issue Reference
N/A