### PR TITLE
Add O365 rule: Audit Log Purge

### DIFF
--- a/rules/office365/o365-audit-log-purge.yml
+++ b/rules/office365/o365-audit-log-purge.yml
@@ -1,0 +1,22 @@
+# Rule version v1.0.0
+
+name: O365 Audit Log Purge
+description: |
+  Detects attempts to purge, delete, or remove audit log data from Office 365.
+  Attackers commonly destroy audit evidence to cover their tracks after compromising
+  an environment. Detection of audit log deletion activities is a strong indicator
+  of an active adversary attempting to evade detection and hinder incident response.
+category: "Defense Evasion"
+technique: "T1070 - Indicator Removal"
+references:
+  - "https://attack.mitre.org/techniques/T1070/"
+dataTypes:
+  - o365
+adversary: origin
+impact:
+  confidentiality: 2
+  integrity: 3
+  availability: 0
+where: oneOf("action", ["DSIPurgeStarted", "AuditSearchDeleted", "HardDelete"])
+groupBy:
+  - adversary.user


### PR DESCRIPTION

## Changes
Adds a new O365 correlation rule o365-audit-log-purge.yml that detects attempts to purge, delete, or remove audit log data from Office 365.

## Reasoning
Attackers routinely attempt to destroy audit evidence after compromising a tenant in order to hinder incident response and forensic reconstruction. Purging O365 audit logs is a high-severity, low-noise signal: legitimate administrative use of these actions is rare and almost always planned, so any hit deserves immediate SOC attention. This rule gives defenders an early indicator that an adversary is actively covering their tracks.

## Issue Reference
N/A