### PR TITLE
fix(rules/google): rebalance CIA impact scores for 3 GCP rules

### DIFF
--- a/rules/cloud/google/gcp_gcs_data_access.yml
+++ b/rules/cloud/google/gcp_gcs_data_access.yml
@@ -4,7 +4,7 @@ dataTypes:
   - google
 name: GCP Cloud Storage — Sensitive Data Access
 impact:
-  confidentiality: 4
+  confidentiality: 3
   integrity: 1
   availability: 1
 category: Discovery

--- a/rules/cloud/google/gcp_iam_policy_changed.yml
+++ b/rules/cloud/google/gcp_iam_policy_changed.yml
@@ -4,9 +4,9 @@ dataTypes:
   - google
 name: GCP IAM Policy Changed — Privilege Escalation
 impact:
-  confidentiality: 4
-  integrity: 4
-  availability: 3
+  confidentiality: 3
+  integrity: 3
+  availability: 2
 category: Privilege Escalation
 technique: "T1098 - Account Manipulation"
 adversary: origin

--- a/rules/cloud/google/gcp_privileged_role_granted.yml
+++ b/rules/cloud/google/gcp_privileged_role_granted.yml
@@ -4,9 +4,9 @@ dataTypes:
   - google
 name: GCP Privileged Role Granted — Owner or Editor
 impact:
-  confidentiality: 5
-  integrity: 5
-  availability: 3
+  confidentiality: 3
+  integrity: 3
+  availability: 1
 category: Privilege Escalation
 technique: "T1078 - Valid Accounts"
 adversary: origin


### PR DESCRIPTION
## What changed
Impact scores were reduced on three GCP rules for event-processor compatibility.

## Why
The previous scores were incorrect. The new values ​​maintain the usefulness of these rules.

## Issue reference
N/A