### PR TITLE
V12- fix(forwarder):  set gRPC metadata type to collector instead of agent

### DIFF
--- a/collectors/forwarder/serv/service.go
+++ b/collectors/forwarder/serv/service.go
@@ -88,7 +88,7 @@ func (p *program) run() {
 
 	ctx = metadata.AppendToOutgoingContext(ctx, "key", cnf.CollectorKey)
 	ctx = metadata.AppendToOutgoingContext(ctx, "id", strconv.Itoa(int(cnf.CollectorID)))
-	ctx = metadata.AppendToOutgoingContext(ctx, "type", "agent")
+	ctx = metadata.AppendToOutgoingContext(ctx, "type", "collector")
 
 	p.goSafe("StartPing", func() {
 		upstream.StartPing(cnf, ctx)


### PR DESCRIPTION
Closes #2290

## Summary

The forwarder was sending `type: "agent"` in the outgoing gRPC metadata context.
The log-auth-proxy rejects streams that don't identify as `"collector"`, causing
an EOF loop that prevented any logs from being forwarded.

## Changes

| File | Change |
|---|---|
| `collectors/forwarder/serv/service.go` | Changed metadata `type` value from `"agent"` to `"collector"` |
