### PR TITLE
v12- fix(installer): add encryptionKey to utmstack_plugins.yaml for cloud …

### DIFF
--- a/installer/docker/plugins.go
+++ b/installer/docker/plugins.go
@@ -21,6 +21,7 @@ type PluginConfig struct {
 	PostgreSQL    PostgreConfig    `yaml:"postgresql,omitempty"`
 	ServerName    string           `yaml:"serverName,omitempty"`
 	InternalKey   string           `yaml:"internalKey,omitempty"`
+	EncryptionKey string           `yaml:"encryptionKey,omitempty"`
 	Env           string           `yaml:"env,omitempty"`
 	AgentManager  string           `yaml:"agentManager,omitempty"`
 	Backend       string           `yaml:"backend,omitempty"`
@@ -82,6 +83,7 @@ func SetPluginsConfigs(conf *config.Config, stack *StackConfig) error {
 		},
 		ServerName:    conf.ServerName,
 		InternalKey:   conf.InternalKey,
+		EncryptionKey: conf.InternalKey,
 		Env:           conf.Branch,
 		AgentManager:  "10.21.199.3:9000",
 		Backend:       "http://backend:8080",


### PR DESCRIPTION
Closes #2292

## Summary

- The installer never wrote `encryptionKey` to the `com.utmstack` block in `utmstack_plugins.yaml`
- All cloud plugins (GCP, AWS, Azure, O365, Sophos, CrowdStrike, Bitdefender) read this key to decrypt tenant secrets at runtime
- Without it, decryption is silently skipped and the raw ciphertext is passed to the cloud SDK causing connection failures

## Changes

| File | Change |
|------|--------|
| `installer/docker/plugins.go` | Added `EncryptionKey` field to `PluginConfig` struct and populated it with `conf.InternalKey` in the `com.utmstack` block |

## Test Plan

- [x] Manually verified on v11-DEV-18: adding `encryptionKey` to `utmstack_plugins.yaml` resolved the GCP plugin failure immediately
- [x] Confirmed backend and plugins use identical AES-CBC + PBKDF2(SHA1, 65536, 16) cipher — same key works for both encrypt and decrypt