### PR TITLE
fix(cisco-meraki): removed duplication of the or operator

### DIFF
--- a/filters/cisco/meraki.yml
+++ b/filters/cisco/meraki.yml
@@ -505,7 +505,7 @@ pipeline:
           params:
             key: actionResult
             value: 'accepted'
-          where: '!equals("log.controlFlag", "Init") && startsWith("log.genericEvent", "Site") && log.merakiGroup=="events" && (contains("log.genericEvent", "queued due to no phase 1") || contains("log.genericEvent", "queued due to no phase1") || || contains("log.genericEvent", "established"))'
+          where: '!equals("log.controlFlag", "Init") && startsWith("log.genericEvent", "Site") && log.merakiGroup=="events" && (contains("log.genericEvent", "queued due to no phase 1") || contains("log.genericEvent", "queued due to no phase1") || contains("log.genericEvent", "established"))'
       # ........................................
       # Event: event spanning-tree guard state change in Meraki MS Switches
       - grok:


### PR DESCRIPTION
## Changes

Fixed a duplicated `||` operator in the CEL expression for the IPsec-SA event `actionResult` step in the Cisco Meraki filter.

## Reasoning
The duplicated `|| ||` is invalid CEL syntax. This caused the add step to fail silently, meaning IPsec-SA events matching "established" would NOT have actionResult: accepted set. The fix removes the extra `||` so the CEL expression evaluates correctly and the field is populated as intended.

## Issue
N/A — typo caught during filter review.