### PR TITLE
Windows: reduce false positives on Suspicious PowerShell (AMSI Bypass) rule

### DIFF
--- a/rules/windows/suspicious_powershell_obfuscation.yml
+++ b/rules/windows/suspicious_powershell_obfuscation.yml
@@ -1,4 +1,4 @@
-# Rule version v1.2.0 (validated 2026-06-24)
+# Rule version v1.3.0 (validated 2026-07-01)
 dataTypes:
   - wineventlog
 name: 'Windows: Suspicious PowerShell (Encoded / Download Cradle / AMSI Bypass)'
@@ -9,11 +9,11 @@ impact:
 category: Execution
 technique: 'T1059.001 - Command and Scripting Interpreter: PowerShell'
 adversary: origin
-description: 'Detects high-risk PowerShell script-block content: download cradles, encoded/hidden execution, reflective loading and AMSI bypass markers. Matches the 4104 script-block text (not the -EncodedCommand flag, to avoid benign false positives).'
+description: 'Detects high-risk PowerShell script-block content: download cradles, encoded/hidden execution, reflective loading and AMSI bypass markers. Matches the 4104 script-block text (not the -EncodedCommand flag, to avoid benign false positives). v1.3.0: excludes the benign injected PSBreakpoint/AMSI "sentinel" instrumentation harness (markers: sentinelbreakpoints, \windows\sentinel\, Po_wer_Spl_oit_Indicators) that otherwise false-positives on the literal "AmsiInitFailed" token it emits on every PowerShell session. The exclusion is per-script-block, so a real payload executed through the harness is a separate 4104 event and still fires.'
 references:
   - https://attack.mitre.org/techniques/T1059/001/
 where: |
-  equals("log.eventCode", "4104") && (regexMatch("log.eventDataScriptBlockText", "(?i)(amsiutils|amsiinitfailed|amsiscanbuffer|virtualalloc|writeprocessmemory|getdelegateforfunctionpointer|invoke-mimikatz|invoke-shellcode|invoke-dllinjection|createremotethread)") || (regexMatch("log.eventDataScriptBlockText", "(?i)(downloadstring|downloadfile|downloaddata|invoke-webrequest|net.webclient|start-bitstransfer)") && regexMatch("log.eventDataScriptBlockText", "(?i)(iex|invoke-expression|-enc |-encodedcommand|-w hidden|-windowstyle hidden|frombase64string)")))
+  equals("log.eventCode", "4104") && !regexMatch("log.eventDataScriptBlockText", "(?i)(sentinelbreakpoints|windows.sentinel.[0-9]|po_wer_spl_oit_indicators)") && (regexMatch("log.eventDataScriptBlockText", "(?i)(amsiutils|amsiinitfailed|amsiscanbuffer|virtualalloc|writeprocessmemory|getdelegateforfunctionpointer|invoke-mimikatz|invoke-shellcode|invoke-dllinjection|createremotethread)") || (regexMatch("log.eventDataScriptBlockText", "(?i)(downloadstring|downloadfile|downloaddata|invoke-webrequest|net.webclient|start-bitstransfer)") && regexMatch("log.eventDataScriptBlockText", "(?i)(iex|invoke-expression|-enc |-encodedcommand|-w hidden|-windowstyle hidden|frombase64string)")))
 groupBy:
   - dataSource
 deduplicateBy: []


### PR DESCRIPTION
## Summary

Reduces false positives on **`rules/windows/suspicious_powershell_obfuscation.yml`** — "Windows: Suspicious PowerShell (Encoded / Download Cradle / AMSI Bypass)" (event 4104, T1059.001). One line of detection logic changed; all attack coverage preserved.

## Problem

The rule fired on **every PowerShell session** on affected hosts. Because the rule uses `groupBy: [dataSource]`, the hits collapsed into a single HIGH alert that accumulated thousands of echoes — drowning out real detections.

## Root cause

The first regex branch matches the token `amsiinitfailed`. The benign, **injected defensive PSBreakpoint/AMSI "sentinel" instrumentation harness** (the `<#sentinelbreakpoints#>` / `Set-PSBreakpoint … out-file ':::::\windows\sentinel\N'` canary tool) is loaded into essentially every PowerShell session and contains the literal string `AmsiInitFailed` (e.g. `Remove-Variable AmsiInitFailed`). That single token tripped the rule on every session.

## Fix

Add a per-script-block exclusion for the harness's unique fingerprints, ANDed ahead of the detection logic:

```
&& !regexMatch("log.eventDataScriptBlockText",
     "(?i)(sentinelbreakpoints|windows.sentinel.[0-9]|po_wer_spl_oit_indicators)")
```

- The three markers (`<#sentinelbreakpoints#>` comment tag, the `\windows\sentinel\N` canary path, the `$Po_wer_Spl_oit_Indicators` array) are unique to this defensive harness and do not appear in real malware.
- The exclusion is **per-script-block**. PowerShell logs each script block as its own 4104 event, so if an attacker actually runs Invoke-Mimikatz *through* the harness, that malicious script block is a **separate** 4104 event and **still fires**.
- **No attack tokens were removed** — AMSI-tamper, reflective-loading, mimikatz/shellcode/dll-injection, and download-cradle+exec detection are unchanged.

## Validation

- Regex logic tested (Go RE2-compatible) against the actual harness text plus real payloads: the harness no longer matches, while the real download cradle (`iex ((New-Object Net.WebClient).DownloadString(...))`), the classic AMSI `amsiInitFailed` SetValue bypass, Invoke-Mimikatz, a reflective shellcode loader, and IWR+IEX cradles all still match. Benign scripts (IWR download without exec, bare `-enc` without a cradle) remain silent.
- Deployed and validated on a live v11 instance (server accepted the definition; verified firing behavior on real telemetry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
