### PR TITLE
feat(plugins/playground): return all matching alerts + drop ephemeral workdir volume

### DIFF
--- a/installer/docker/compose.go
+++ b/installer/docker/compose.go
@@ -324,7 +324,6 @@ func (c *Compose) Populate(conf *config.Config, stack *StackConfig) error {
 			utils.MakeDir(0777, stack.EventsEngineWorkdir, "logs") + ":/workdir/logs",
 			stack.Cert + ":/cert",
 			conf.UpdatesFolder + ":/updates",
-			utils.MakeDir(0777, stack.EventsEngineWorkdir, "playground") + ":/playground-workdir",
 		},
 		Environment: []string{
 			"WORK_DIR=/workdir",

--- a/plugins/playground/internal/runner/runner.go
+++ b/plugins/playground/internal/runner/runner.go
@@ -14,16 +14,25 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
+type StopReason string
+
+const (
+	StopReasonQuiet    StopReason = "quiet"
+	StopReasonHardCap  StopReason = "hard_cap"
+	StopReasonNoAlerts StopReason = "no_alerts"
+)
+
 type RunState struct {
 	Active bool
 	UUID   string
 }
 
 type RunResult struct {
-	UUID     string          `json:"uuid"`
-	Event    json.RawMessage `json:"event,omitempty"`
-	Alert    json.RawMessage `json:"alert,omitempty"`
-	TimedOut bool            `json:"timedOut"`
+	UUID       string            `json:"uuid"`
+	Event      json.RawMessage   `json:"event,omitempty"`
+	Alerts     []json.RawMessage `json:"alerts,omitempty"`
+	TimedOut   bool              `json:"timedOut"`
+	StopReason StopReason        `json:"stopReason,omitempty"`
 }
 
 type Runner struct {
@@ -78,12 +87,17 @@ func (r *Runner) Run(ctx context.Context, log *plugins.Log) (*RunResult, error) 
 		return &RunResult{UUID: log.Id, TimedOut: true}, nil
 	}
 
-	alert, err := r.awaitAlert(ctx, ws.resultingAlert, log.Id)
+	alerts, stop, err := r.awaitAlerts(ctx, ws.resultingAlert, log.Id)
 	if err != nil {
 		return nil, err
 	}
 
-	return &RunResult{UUID: log.Id, Event: event, Alert: alert}, nil
+	return &RunResult{
+		UUID:       log.Id,
+		Event:      event,
+		Alerts:     alerts,
+		StopReason: stop,
+	}, nil
 }
 
 func (r *Runner) acquireRun(log *plugins.Log) func() {
@@ -143,34 +157,63 @@ func (ws workspace) submitLog(log *plugins.Log) error {
 }
 
 func (r *Runner) awaitEvent(ctx context.Context, path, id string) (json.RawMessage, bool, error) {
-	return r.pollUntil(ctx, r.eventTimeout, func() json.RawMessage {
-		return findByID(path, id)
-	})
-}
-
-func (r *Runner) awaitAlert(ctx context.Context, path, eventID string) (json.RawMessage, error) {
-	result, _, err := r.pollUntil(ctx, r.alertGrace, func() json.RawMessage {
-		return findAlertByEventID(path, eventID)
-	})
-	return result, err
-}
-
-func (r *Runner) pollUntil(ctx context.Context, deadline time.Duration, probe func() json.RawMessage) (json.RawMessage, bool, error) {
 	ticker := time.NewTicker(r.pollInterval)
 	defer ticker.Stop()
 
-	end := time.Now().Add(deadline)
+	end := time.Now().Add(r.eventTimeout)
 	for {
 		select {
 		case <-ctx.Done():
 			return nil, false, ctx.Err()
 		case <-ticker.C:
 		}
-		if result := probe(); result != nil {
+		if result := findByID(path, id); result != nil {
 			return result, false, nil
 		}
 		if !time.Now().Before(end) {
 			return nil, true, nil
+		}
+	}
+}
+
+func (r *Runner) awaitAlerts(ctx context.Context, path, eventID string) ([]json.RawMessage, StopReason, error) {
+	ticker := time.NewTicker(r.pollInterval)
+	defer ticker.Stop()
+
+	var alerts []json.RawMessage
+	seenIDs := make(map[string]struct{})
+
+	now := time.Now()
+	hardDeadline := now.Add(r.eventTimeout)
+	quietDeadline := now.Add(r.alertGrace)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return alerts, "", ctx.Err()
+		case <-ticker.C:
+		}
+
+		newAlerts := findAlertsByEventID(path, eventID, seenIDs)
+		if len(newAlerts) > 0 {
+			alerts = append(alerts, newAlerts...)
+			quietDeadline = time.Now().Add(r.alertGrace)
+		}
+
+		now = time.Now()
+
+		if !now.Before(hardDeadline) {
+			if len(alerts) == 0 {
+				return nil, StopReasonNoAlerts, nil
+			}
+			return alerts, StopReasonHardCap, nil
+		}
+
+		if !now.Before(quietDeadline) {
+			if len(alerts) == 0 {
+				return nil, StopReasonNoAlerts, nil
+			}
+			return alerts, StopReasonQuiet, nil
 		}
 	}
 }

--- a/plugins/playground/internal/runner/scan.go
+++ b/plugins/playground/internal/runner/scan.go
@@ -11,6 +11,7 @@ type idOnly struct {
 }
 
 type alertProbe struct {
+	ID     string   `json:"id"`
 	Events []idOnly `json:"events"`
 }
 
@@ -19,7 +20,7 @@ func scanLines(path string, match func(line string) bool) json.RawMessage {
 	if err != nil {
 		return nil
 	}
-	for _, line := range strings.Split(string(data), "\n") {
+	for line := range strings.SplitSeq(string(data), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
@@ -41,17 +42,43 @@ func findByID(path, id string) json.RawMessage {
 	})
 }
 
-func findAlertByEventID(path, eventID string) json.RawMessage {
-	return scanLines(path, func(line string) bool {
+func findAlertsByEventID(path, eventID string, seenIDs map[string]struct{}) []json.RawMessage {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+
+	var out []json.RawMessage
+	for line := range strings.SplitSeq(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
 		var probe alertProbe
 		if err := json.Unmarshal([]byte(line), &probe); err != nil {
-			return false
+			continue
 		}
+
+		matched := false
 		for _, e := range probe.Events {
 			if e.ID == eventID {
-				return true
+				matched = true
+				break
 			}
 		}
-		return false
-	})
+		if !matched {
+			continue
+		}
+
+		if probe.ID != "" {
+			if _, seen := seenIDs[probe.ID]; seen {
+				continue
+			}
+			seenIDs[probe.ID] = struct{}{}
+		}
+
+		out = append(out, json.RawMessage(line))
+	}
+	return out
 }


### PR DESCRIPTION
## Summary

Two related fixes to the playground plugin so the `POST /playground/run`
flow can actually surface everything the event-processor produces, and so the
ephemeral workdir stops leaking state between container restarts.

Reference: internal discussion, no tracked issue.

## Changes

### 1. `feat(plugins/playground): return all matching alerts with moving-window collection`

**What was broken.** The run endpoint returned a single alert per event
even when multiple rules matched the same event. The correlation writer
(`saw` plugin in EventProcessor) already appends one NDJSON line per
alert to `resulting_alert.json`, but the consumer side of the pipeline
threw away everything past the first match:

- `RunResult.Alert` was a singular `json.RawMessage`, so the struct
  physically could not carry more than one alert.
- `findAlertByEventID` in `scan.go` short-circuited on the first line
  matching the event id.
- `awaitAlert` waited a fixed `AlertGrace` (2s) after the event was
  seen and then returned, so alerts that arrived after that window
  were dropped even if the file contained them.

**What changed.**

- `RunResult.Alert (json.RawMessage) → Alerts ([]json.RawMessage)`.
  **Breaking change** in the JSON response: the `alert` field is gone
  and replaced by `alerts`.
- New `RunResult.StopReason` field: `quiet` | `hard_cap` | `no_alerts`.
  Lets the client tell "these are all the alerts" (`quiet`) apart from
  "we cut the wait short, more may be pending" (`hard_cap`).
- `findAlertByEventID` → `findAlertsByEventID` — collects every
  matching line and dedupes by `alert.id` across polls via a
  caller-owned seen set.
- `awaitAlert` → `awaitAlerts`: moving quiet window bounded by an
  absolute hard cap:
  - Quiet window (`AlertGrace`, 2s) resets on every new alert
    observed, so bursts of alerts are not truncated mid-burst.
  - Hard cap (`EventTimeout`, 15s) is the absolute per-run deadline
    so a noisy rule cannot hold the HTTP request open indefinitely.
  - If no alert arrives before the initial `AlertGrace` elapses,
    we return `no_alerts` — same behavior as before for the empty
    case.

**Why moving window instead of a fixed grace.** A fixed grace fails
when the correlation pipeline is slow: multiple rules matching the same
event can produce alerts spread out over more than 2s. The moving
window adapts to the actual arrival rate; the hard cap prevents
pathological cases from hanging the request.

### 2. `feat(installer): drop ephemeral playground-workdir volume`

The playground workdir only needs to survive the lifetime of the
event-processor container: `input/`, `resulting_log.json` and
`resulting_alert.json` are all truncated at the start of every run,
and nothing is expected to persist across restarts.