### PR TITLE
v12- Wire up playground UI for filter/rule testing

### DIFF
--- a/frontend/src/features/alerting-rules/pages/AlertingRulesPage.tsx
+++ b/frontend/src/features/alerting-rules/pages/AlertingRulesPage.tsx
@@ -7,6 +7,7 @@ import {
   CheckCircle2,
   Code2,
   Crosshair,
+  FlaskConical,
   LayoutList,
   Loader2,
   Lock,
@@ -28,6 +29,7 @@ import { InfiniteScrollSentinel } from '@/shared/components/ui/infinite-scroll'
 import { ConfirmDialog } from '@/shared/components/ui/confirm-dialog'
 import { YamlCodeEditor } from '@/shared/components/YamlCodeEditor'
 import { useDateFormat } from '@/shared/lib/datetime'
+import { TestPlaygroundModal } from '@/features/playground/components/TestPlaygroundModal'
 import {
   alertingRulesHttpService as svc,
   AlertingRulesHttpError,
@@ -86,6 +88,7 @@ export function AlertingRulesPage() {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [importBusy, setImportBusy] = useState(false)
   const [importResults, setImportResults] = useState<ImportRulesResponse | null>(null)
+  const [showTestModal, setShowTestModal] = useState(false)
 
   const onImportFiles = async (fileList: FileList | null) => {
     if (!fileList || fileList.length === 0) return
@@ -165,6 +168,15 @@ export function AlertingRulesPage() {
     }
   }
 
+  // Test entry point (Entry A) scope: dataTypes with ≥1 active rule among the
+  const testDataTypes = [
+    ...new Set(
+      rules
+        .filter((r) => r.ruleActive)
+        .flatMap((r) => (r.dataTypes ?? []).filter((d) => d.included).map((d) => d.dataType)),
+    ),
+  ]
+
   const remove = (r: CorrelationRule) => setPendingDelete(r)
 
   const confirmDelete = async () => {
@@ -202,6 +214,10 @@ export function AlertingRulesPage() {
           <Button size="sm" variant="outline" disabled={importBusy} onClick={() => fileInputRef.current?.click()}>
             {importBusy ? <Loader2 size={14} className="mr-1.5 animate-spin" /> : <Upload size={14} className="mr-1.5" />}
             {t('alertingRules.import.button')}
+          </Button>
+          <Button size="sm" variant="outline" onClick={() => setShowTestModal(true)}>
+            <FlaskConical size={14} className="mr-1.5" />
+            {t('alertingRules.test')}
           </Button>
           <Button size="sm" onClick={() => setCreating(true)}>
             <Plus size={14} className="mr-1.5" /> {t('alertingRules.new')}
@@ -268,6 +284,7 @@ export function AlertingRulesPage() {
       {open && <RuleDrawer rule={open} dataTypeOptions={dataTypeOptions} onClose={() => setOpen(null)} onToggle={toggleActive} onDelete={remove} onSaved={() => { setOpen(null); refresh() }} t={t} />}
       {creating && <RuleDrawer create dataTypeOptions={dataTypeOptions} onClose={() => setCreating(false)} onSaved={() => { setCreating(false); refresh() }} t={t} />}
       {importResults && <ImportResultsDialog res={importResults} onClose={() => setImportResults(null)} t={t} />}
+      {showTestModal && <TestPlaygroundModal mode="rule" dataTypeOptions={testDataTypes} onClose={() => setShowTestModal(false)} />}
       <ConfirmDialog
         open={pendingDelete != null}
         title={t('alertingRules.editor.delete') ?? 'Delete'}
@@ -416,6 +433,7 @@ function RuleDrawer({
   const [editing, setEditing] = useState(!!create)
   const [form, setForm] = useState<RuleFormState>(() => ruleToForm(rule))
   const [busy, setBusy] = useState(false)
+  const [showTestModal, setShowTestModal] = useState(false)
 
   // Visual ↔ Code. The structured form stays canonical; Code shows/edits the
   // whole rule as YAML and syncs back into the form on toggle / save.
@@ -534,15 +552,31 @@ function RuleDrawer({
           )}
         </div>
 
-        {showForm && (
-          <footer className="flex items-center justify-end gap-2 border-t border-border px-6 py-3">
-            {!create && <Button size="sm" variant="outline" onClick={cancelEdit} disabled={busy}>{t('alertingRules.editor.cancel')}</Button>}
-            <Button size="sm" onClick={() => void save()} disabled={busy}>
-              {busy ? <Loader2 size={13} className="mr-1.5 animate-spin" /> : null} {t('alertingRules.editor.save')}
+        {(showForm || rule) && (
+          <footer className="flex items-center justify-between gap-2 border-t border-border px-6 py-3">
+            <Button size="sm" variant="outline" onClick={() => setShowTestModal(true)}>
+              <FlaskConical size={13} className="mr-1.5" /> {t('alertingRules.editor.test')}
             </Button>
+            {showForm && (
+              <div className="flex items-center gap-2">
+                {!create && <Button size="sm" variant="outline" onClick={cancelEdit} disabled={busy}>{t('alertingRules.editor.cancel')}</Button>}
+                <Button size="sm" onClick={() => void save()} disabled={busy}>
+                  {busy ? <Loader2 size={13} className="mr-1.5 animate-spin" /> : null} {t('alertingRules.editor.save')}
+                </Button>
+              </div>
+            )}
           </footer>
         )}
       </div>
+
+      {showTestModal && (
+        <TestPlaygroundModal
+          mode="rule"
+          dataTypeOptions={form.dataTypes}
+          draftContent={ruleFormToYaml(form)}
+          onClose={() => setShowTestModal(false)}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/features/parsing-filters/components/FilterFormDrawer.tsx
+++ b/frontend/src/features/parsing-filters/components/FilterFormDrawer.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
-import { Code2, LayoutList, Loader2, Lock, Trash2, X } from 'lucide-react'
+import { Code2, FlaskConical, LayoutList, Loader2, Lock, Trash2, X } from 'lucide-react'
 import { cn } from '@/shared/lib/utils'
 import { Button } from '@/shared/components/ui/button'
 import { Input } from '@/shared/components/ui/input'
@@ -12,6 +12,7 @@ import {
 } from '@/features/data-processing/services/data-processing-http.service'
 import type { DataTypeOption, Filter } from '@/features/data-processing/types/data-processing.types'
 import { regexPatternsHttpService, type RegexPattern } from '@/features/regex-patterns/services/regex-patterns-http.service'
+import { TestPlaygroundModal } from '@/features/playground/components/TestPlaygroundModal'
 import { displayName, emptyModel, parseFilter, sanitizeFileName, serializeFilter, type FilterModel } from '../lib/filter-model'
 import { VisualFilterEditor } from './VisualFilterEditor'
 import { PatternInsertButton } from './PatternInsertButton'
@@ -41,6 +42,7 @@ export function FilterFormDrawer({ filter, creating, onClose, onSaved }: Props) 
   )
   const [saving, setSaving] = useState(false)
   const [confirmDelete, setConfirmDelete] = useState(false)
+  const [showTestModal, setShowTestModal] = useState(false)
 
   // Visual ↔ Code. Content (YAML string) stays canonical; the visual editor
   // serializes back into it on every change.
@@ -266,14 +268,28 @@ export function FilterFormDrawer({ filter, creating, onClose, onSaved }: Props) 
                 </button>
               ))}
           </div>
-          {!readOnly && (
-            <Button size="sm" disabled={!dirty || saving} onClick={() => void save()}>
-              {saving ? <Loader2 size={13} className="mr-1.5 animate-spin" /> : null}
-              {saving ? t('parsingFilters.editor.saving') : t('parsingFilters.editor.save')}
+          <div className="flex items-center gap-2">
+            <Button size="sm" variant="outline" onClick={() => setShowTestModal(true)}>
+              <FlaskConical size={13} className="mr-1.5" /> {t('parsingFilters.editor.test')}
             </Button>
-          )}
+            {!readOnly && (
+              <Button size="sm" disabled={!dirty || saving} onClick={() => void save()}>
+                {saving ? <Loader2 size={13} className="mr-1.5 animate-spin" /> : null}
+                {saving ? t('parsingFilters.editor.saving') : t('parsingFilters.editor.save')}
+              </Button>
+            )}
+          </div>
         </footer>
       </div>
+
+      {showTestModal && (
+        <TestPlaygroundModal
+          mode="filter"
+          dataTypeOptions={model.dataTypes}
+          draftContent={content}
+          onClose={() => setShowTestModal(false)}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/features/parsing-filters/pages/ParsingFiltersPage.tsx
+++ b/frontend/src/features/parsing-filters/pages/ParsingFiltersPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { AlertTriangle, ChevronDown, ChevronUp, FileCode, Loader2, Lock, Plus, RefreshCw, Search } from 'lucide-react'
+import { AlertTriangle, ChevronDown, ChevronUp, FileCode, FlaskConical, Loader2, Lock, Plus, RefreshCw, Search } from 'lucide-react'
 import { toast } from 'sonner'
 import { cn } from '@/shared/lib/utils'
 import { Button } from '@/shared/components/ui/button'
@@ -9,6 +9,7 @@ import { Input } from '@/shared/components/ui/input'
 import { InfiniteScrollSentinel } from '@/shared/components/ui/infinite-scroll'
 import { filtersHttpService } from '@/features/data-processing/services/data-processing-http.service'
 import type { Filter } from '@/features/data-processing/types/data-processing.types'
+import { TestPlaygroundModal } from '@/features/playground/components/TestPlaygroundModal'
 import { FilterFormDrawer } from '../components/FilterFormDrawer'
 import { displayName } from '../lib/filter-model'
 
@@ -34,6 +35,7 @@ export function ParsingFiltersPage() {
   const [error, setError] = useState(false)
   const [editing, setEditing] = useState<{ filter: Filter; creating: boolean } | null>(null)
   const [preparingNew, setPreparingNew] = useState(false)
+  const [showTestModal, setShowTestModal] = useState(false)
 
   // Deep-link: ?dataType=<value> pre-filters the list to that data type
   // (e.g. opened from an integration's "Filters" button).
@@ -167,6 +169,10 @@ export function ParsingFiltersPage() {
           <span><span className="font-medium text-foreground">{total}</span> {t('parsingFilters.title').toLowerCase()}</span>
         </div>
         <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm" onClick={() => setShowTestModal(true)}>
+            <FlaskConical size={14} className="mr-1.5" />
+            {t('parsingFilters.testPipeline')}
+          </Button>
           <Button size="sm" onClick={() => void startCreate()} disabled={preparingNew}>
             {preparingNew ? <Loader2 size={14} className="mr-1.5 animate-spin" /> : <Plus size={14} className="mr-1.5" />}
             {t('parsingFilters.new')}
@@ -283,6 +289,10 @@ export function ParsingFiltersPage() {
             load()
           }}
         />
+      )}
+
+      {showTestModal && (
+        <TestPlaygroundModal mode="filter" dataTypeOptions={dataTypeOptions} onClose={() => setShowTestModal(false)} />
       )}
     </div>
   )

--- a/frontend/src/features/playground/components/AlertsListView.tsx
+++ b/frontend/src/features/playground/components/AlertsListView.tsx
@@ -1,0 +1,142 @@
+import { useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ChevronDown, ChevronRight, Loader2 } from 'lucide-react'
+import { cn } from '@/shared/lib/utils'
+import { flatten, isSeverityField, SEVERITY_TONE, HIDDEN_FIELDS } from '../lib/event-fields'
+
+interface Props {
+  alerts?: unknown[]
+  loading?: boolean
+}
+
+// Common keys the underlying rule engine may use for an alert's display name,
+// checked in order against the flattened record (dotted paths included).
+const NAME_KEYS = ['name', 'ruleName', 'rule.name', 'alertName']
+
+function findFirst(flat: Record<string, unknown>, keys: string[]): unknown {
+  for (const k of keys) if (flat[k] != null) return flat[k]
+  return undefined
+}
+
+/** First flattened key/value pair that looks like a severity/level field. */
+function findSeverity(flat: Record<string, unknown>): { key: string; value: unknown } | undefined {
+  const key = Object.keys(flat).find((k) => isSeverityField(k))
+  return key ? { key, value: flat[key] } : undefined
+}
+
+/**
+ * Renders the `alerts` half of a rule-mode playground test — a collapsible
+ * row per alert (name + severity chip in the header, chevron to expand) whose
+ * body is a flattened field table sharing the exact styling and helpers used
+ * by `ParsedEventView`'s field table (no icons, no extra tinting on field
+ * names — only the severity value itself gets a colored pill).
+ */
+export function AlertsListView({ alerts, loading }: Props) {
+  const { t } = useTranslation()
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center gap-2 rounded-md border border-border bg-card px-3 py-10 text-sm text-muted-foreground">
+        <Loader2 size={14} className="animate-spin" />
+      </div>
+    )
+  }
+
+  if (!alerts) {
+    return (
+      <div className="flex h-full items-center justify-center rounded-md border border-dashed border-border px-3 py-10 text-center text-sm text-muted-foreground">
+        {t('playground.alerts.empty')}
+      </div>
+    )
+  }
+
+  if (alerts.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center rounded-md border border-border bg-card px-3 py-10 text-center text-sm text-muted-foreground">
+        {t('playground.alerts.none')}
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden rounded-md border border-border bg-card">
+      <div className="flex items-center justify-between gap-3 border-b border-border/60 px-3 py-2">
+        <span className="text-[11px] text-muted-foreground">{t('playground.alerts.count', { count: alerts.length })}</span>
+      </div>
+      <div className="min-h-0 flex-1 overflow-auto p-3">
+        <div className="space-y-2">
+          {alerts.map((alert, i) => (
+            <AlertRow key={i} alert={alert} />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function AlertRow({ alert }: { alert: unknown }) {
+  const [open, setOpen] = useState(false)
+
+  const flat = useMemo(() => flatten(alert), [alert])
+  const name = useMemo(() => {
+    const v = findFirst(flat, NAME_KEYS)
+    return v != null ? String(v) : undefined
+  }, [flat])
+  const severity = useMemo(() => findSeverity(flat), [flat])
+  const sevTone = severity ? SEVERITY_TONE[String(severity.value).toLowerCase()] : undefined
+
+  const rows = useMemo(
+    () =>
+      Object.entries(flat)
+        .filter(([k]) => !HIDDEN_FIELDS.has(k))
+        .map(([k, v]) => ({ key: k, value: v }))
+        .sort((a, b) => a.key.localeCompare(b.key)),
+    [flat],
+  )
+
+  return (
+    <div className="overflow-hidden rounded-md border border-border">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs hover:bg-muted/40"
+      >
+        {open ? <ChevronDown size={13} className="shrink-0 text-muted-foreground" /> : <ChevronRight size={13} className="shrink-0 text-muted-foreground" />}
+        <span className="min-w-0 flex-1 truncate font-medium">{name ?? '—'}</span>
+        {severity &&
+          (sevTone ? (
+            <span className={cn('inline-flex shrink-0 rounded px-1.5 py-0.5 font-mono text-[11px]', sevTone)}>{String(severity.value)}</span>
+          ) : (
+            <span className="shrink-0 font-mono text-[11px] text-muted-foreground">{String(severity.value)}</span>
+          ))}
+      </button>
+      {open && (
+        <div className="overflow-hidden border-t border-border">
+          {rows.map((row, i) => {
+            const rowSevTone = isSeverityField(row.key) ? SEVERITY_TONE[String(row.value).toLowerCase()] : undefined
+            return (
+              <div
+                key={row.key}
+                className={cn(
+                  'grid grid-cols-[minmax(140px,220px)_1fr] items-start gap-3 px-3 py-1.5 text-[12px] leading-relaxed',
+                  i < rows.length - 1 && 'border-b border-border/60',
+                )}
+              >
+                <div className="truncate font-mono text-muted-foreground" title={row.key}>
+                  {row.key}
+                </div>
+                {rowSevTone ? (
+                  <div>
+                    <span className={cn('inline-flex rounded px-1.5 py-0.5 font-mono text-[11px]', rowSevTone)}>{String(row.value)}</span>
+                  </div>
+                ) : (
+                  <div className="break-all font-mono">{String(row.value)}</div>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/features/playground/components/ParsedEventView.tsx
+++ b/frontend/src/features/playground/components/ParsedEventView.tsx
@@ -1,0 +1,179 @@
+import { useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+import { Check, Copy, Loader2, Search } from 'lucide-react'
+import { cn } from '@/shared/lib/utils'
+import { flatten, isSeverityField, SEVERITY_TONE, HIDDEN_FIELDS } from '../lib/event-fields'
+
+interface Props {
+  event?: Record<string, unknown>
+  loading?: boolean
+  /** Round-trip time for the last test call, for display next to the result. */
+  elapsedMs?: number
+}
+
+type Tab = 'fields' | 'json'
+
+function formatElapsed(ms: number): string {
+  return ms < 1000 ? `${Math.round(ms)}ms` : `${(ms / 1000).toFixed(1)}s`
+}
+
+/**
+ * Purpose-built result view for a playground test — NOT shared with
+ * log-explorer. Shows the parsed event as a flattened, searchable field
+ * table (default) or raw JSON, with severity color-coding.
+ */
+export function ParsedEventView({ event, loading, elapsedMs }: Props) {
+  const { t } = useTranslation()
+  const [tab, setTab] = useState<Tab>('fields')
+  const [copied, setCopied] = useState(false)
+  const [search, setSearch] = useState('')
+
+  const rows = useMemo(() => {
+    if (!event) return []
+    const flat = flatten(event)
+    return Object.entries(flat)
+      .filter(([k]) => !HIDDEN_FIELDS.has(k))
+      .map(([k, v]) => ({ key: k, value: v }))
+      .sort((a, b) => a.key.localeCompare(b.key))
+  }, [event])
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    if (!q) return rows
+    return rows.filter((r) => r.key.toLowerCase().includes(q) || String(r.value).toLowerCase().includes(q))
+  }, [rows, search])
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center gap-2 rounded-md border border-border bg-card px-3 py-10 text-sm text-muted-foreground">
+        <Loader2 size={14} className="animate-spin" /> {t('playground.result.loading')}
+      </div>
+    )
+  }
+
+  if (!event) {
+    return (
+      <div className="flex h-full items-center justify-center rounded-md border border-dashed border-border px-3 py-10 text-center text-sm text-muted-foreground">
+        {t('playground.result.empty')}
+      </div>
+    )
+  }
+
+  const json = JSON.stringify(event, null, 2)
+  const copy = () => {
+    void navigator.clipboard.writeText(json)
+    setCopied(true)
+    toast.success(t('playground.result.copied'))
+    setTimeout(() => setCopied(false), 1500)
+  }
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden rounded-md border border-border bg-card">
+      <div className="flex items-center justify-between gap-3 border-b border-border/60 px-3 py-2">
+        <div className="flex items-center gap-4">
+          <TabBtn id="fields" current={tab} onChange={setTab}>
+            {t('playground.result.tabs.fields')}
+          </TabBtn>
+          <TabBtn id="json" current={tab} onChange={setTab}>
+            {t('playground.result.tabs.json')}
+          </TabBtn>
+        </div>
+        <div className="flex items-center gap-3">
+          {elapsedMs != null && (
+            <span className="text-[11px] text-muted-foreground" title={t('playground.result.elapsedHint')}>
+              {t('playground.result.elapsed', { time: formatElapsed(elapsedMs) })}
+            </span>
+          )}
+          <span className="text-[11px] text-muted-foreground">{t('playground.result.fieldsCount', { count: rows.length })}</span>
+          <button
+            type="button"
+            onClick={copy}
+            className="flex h-6 items-center gap-1.5 rounded-md px-1.5 text-[11px] text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            {copied ? <Check size={11} className="text-emerald-500" /> : <Copy size={11} />}
+            {copied ? t('playground.result.copied') : t('playground.result.copy')}
+          </button>
+        </div>
+      </div>
+
+      {tab === 'fields' && (
+        <div className="border-b border-border/60 px-3 py-2">
+          <div className="relative">
+            <Search size={12} className="absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground" />
+            <input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder={t('playground.result.searchPlaceholder')}
+              className="h-7 w-full rounded-md border border-input bg-background/40 pl-6 pr-2 text-[11px] focus-visible:border-ring focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            />
+          </div>
+        </div>
+      )}
+
+      <div className="min-h-0 flex-1 overflow-auto p-3">
+        {tab === 'fields' ? (
+          filtered.length === 0 ? (
+            <p className="px-1 py-6 text-center text-[12px] text-muted-foreground">{t('playground.result.noMatch')}</p>
+          ) : (
+            <div className="overflow-hidden rounded-md border border-border">
+              {filtered.map((row, i) => {
+                const sevTone = isSeverityField(row.key) ? SEVERITY_TONE[String(row.value).toLowerCase()] : undefined
+                return (
+                  <div
+                    key={row.key}
+                    className={cn(
+                      'grid grid-cols-[minmax(140px,220px)_1fr] items-start gap-3 px-3 py-1.5 text-[12px] leading-relaxed',
+                      i < filtered.length - 1 && 'border-b border-border/60'
+                    )}
+                  >
+                    <div className="truncate font-mono text-muted-foreground" title={row.key}>
+                      {row.key}
+                    </div>
+                    {sevTone ? (
+                      <div>
+                        <span className={cn('inline-flex rounded px-1.5 py-0.5 font-mono text-[11px]', sevTone)}>
+                          {String(row.value)}
+                        </span>
+                      </div>
+                    ) : (
+                      <div className="break-all font-mono">{String(row.value)}</div>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          )
+        ) : (
+          <pre className="overflow-x-auto font-mono text-[11px] leading-relaxed">{json}</pre>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function TabBtn({
+  id,
+  current,
+  onChange,
+  children,
+}: {
+  id: Tab
+  current: Tab
+  onChange: (t: Tab) => void
+  children: React.ReactNode
+}) {
+  const active = id === current
+  return (
+    <button
+      type="button"
+      onClick={() => onChange(id)}
+      className={cn(
+        'relative -mb-2 border-b-2 pb-2 text-xs transition-colors',
+        active ? 'border-foreground font-medium text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground'
+      )}
+    >
+      {children}
+    </button>
+  )
+}

--- a/frontend/src/features/playground/components/TestPlaygroundModal.tsx
+++ b/frontend/src/features/playground/components/TestPlaygroundModal.tsx
@@ -1,0 +1,187 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { AlertTriangle, Info, Loader2, PlayCircle, X } from 'lucide-react'
+import { cn } from '@/shared/lib/utils'
+import { Button } from '@/shared/components/ui/button'
+import { PlaygroundHttpError, playgroundHttpService } from '../services/playground-http.service'
+import type { PlaygroundMode, TestFilterResponse } from '../types'
+import { ParsedEventView } from './ParsedEventView'
+import { AlertsListView } from './AlertsListView'
+
+type ErrorKind = 'busy' | 'timeout' | 'validation' | 'server' | null
+
+// Mirrors the backend's raw-log body limit — shown client-side to preempt a
+// 413 rather than let the user discover it only after Run fails.
+const MAX_BYTES = 1024 * 1024
+
+interface Props {
+  mode: PlaygroundMode
+  /** Entry A: active dataTypes from the catalog. Entry B: `model.dataTypes` of the draft. */
+  dataTypeOptions: string[]
+  /** Present only for Entry B (unsaved draft content); omitted tests the live pipeline. */
+  draftContent?: string
+  onClose: () => void
+}
+
+export function TestPlaygroundModal({ mode, dataTypeOptions, draftContent, onClose }: Props) {
+  const { t } = useTranslation()
+  const [selectedDataType, setSelectedDataType] = useState(dataTypeOptions[0] ?? '')
+  const [rawLog, setRawLog] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [result, setResult] = useState<TestFilterResponse | null>(null)
+  const [errorKind, setErrorKind] = useState<ErrorKind>(null)
+  const [elapsedMs, setElapsedMs] = useState<number | null>(null)
+
+  const noDataTypes = dataTypeOptions.length === 0
+  // Entry B (draft) usually has exactly one dataType — showing an interactive
+  // dropdown implies a choice that doesn't exist, so lock it instead.
+  const singleDataType = dataTypeOptions.length === 1
+  const byteSize = new TextEncoder().encode(rawLog).length
+  const overLimit = byteSize > MAX_BYTES
+  const nearLimit = !overLimit && byteSize > MAX_BYTES * 0.9
+  const runDisabled = loading || !rawLog.trim() || !selectedDataType || noDataTypes || overLimit
+
+  const run = async () => {
+    if (runDisabled) return
+    setLoading(true)
+    setErrorKind(null)
+    setResult(null)
+    setElapsedMs(null)
+    const start = performance.now()
+    try {
+      const log = { dataType: selectedDataType, raw: rawLog }
+      const response =
+        mode === 'rule'
+          ? await playgroundHttpService.testRule({ log, rule: draftContent !== undefined ? { content: draftContent } : undefined })
+          : await playgroundHttpService.testFilter({ log, filter: draftContent !== undefined ? { content: draftContent } : undefined })
+      setElapsedMs(performance.now() - start)
+      if (response.timedOut) {
+        setErrorKind('timeout')
+      } else {
+        setResult(response)
+      }
+    } catch (err) {
+      if (err instanceof PlaygroundHttpError && err.status === 503) setErrorKind('busy')
+      else if (err instanceof PlaygroundHttpError && err.status === 400) setErrorKind('validation')
+      // 500/502 map here explicitly; everything else (413, network, etc.)
+      // falls back to the same generic server copy.
+      else setErrorKind('server')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 p-4 backdrop-blur-sm"
+      onClick={(e) => {
+        // This modal may be nested inside another overlay (e.g. FilterFormDrawer);
+        // stop the click here so it doesn't also close the parent.
+        e.stopPropagation()
+        onClose()
+      }}
+    >
+      <div
+        className="flex h-[90vh] w-[95vw] max-w-[1600px] flex-col overflow-hidden rounded-xl border border-border bg-card shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="flex items-center justify-between gap-4 border-b border-border px-6 py-4">
+          <h2 className="flex items-center gap-2 text-lg font-semibold">
+            <PlayCircle size={16} className="text-primary" /> {t('playground.title')}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            <X size={16} />
+          </button>
+        </header>
+
+        <div className="grid min-h-0 flex-1 grid-cols-1 gap-6 overflow-y-auto px-6 py-5 md:grid-cols-2 md:overflow-hidden">
+          {/* Left column: test inputs */}
+          <div className="flex min-h-0 flex-col gap-4 md:overflow-y-auto md:pr-1">
+            {noDataTypes && (
+              <div className="flex items-center gap-2 rounded-md bg-amber-500/10 px-3 py-2 text-xs text-amber-600 dark:text-amber-300">
+                <Info size={13} /> {t('playground.noDataTypes')}
+              </div>
+            )}
+
+            <div className="space-y-1.5">
+              <label className="block text-xs font-medium text-foreground/80">{t('playground.dataTypeLabel')}</label>
+              <select
+                value={selectedDataType}
+                onChange={(e) => setSelectedDataType(e.target.value)}
+                disabled={noDataTypes || singleDataType}
+                title={singleDataType ? t('playground.dataTypeSingleHint') : undefined}
+                className="h-9 w-full rounded-md border border-input bg-background px-2.5 text-xs text-foreground focus-visible:border-ring focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-50"
+              >
+                {noDataTypes ? (
+                  <option value="">{t('playground.dataTypePlaceholder')}</option>
+                ) : (
+                  dataTypeOptions.map((dt) => (
+                    <option key={dt} value={dt}>
+                      {dt}
+                    </option>
+                  ))
+                )}
+              </select>
+            </div>
+
+            <div className="space-y-1.5">
+              <div className="flex items-center justify-between">
+                <label className="block text-xs font-medium text-foreground/80">{t('playground.rawLogLabel')}</label>
+                <span className={cn('text-[11px]', overLimit ? 'text-red-500' : nearLimit ? 'text-amber-500' : 'text-muted-foreground')}>
+                  {t('playground.rawLogCounter', { chars: rawLog.length, kb: (byteSize / 1024).toFixed(1) })}
+                </span>
+              </div>
+              <textarea
+                value={rawLog}
+                onChange={(e) => setRawLog(e.target.value)}
+                rows={12}
+                spellCheck={false}
+                autoCorrect="off"
+                autoCapitalize="off"
+                placeholder={t('playground.rawLogPlaceholder')}
+                className="w-full resize-none rounded-md border border-input bg-background/40 p-2 font-mono text-xs focus-visible:border-ring focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              />
+              {overLimit && <p className="text-[11px] text-red-500">{t('playground.rawLogTooLarge')}</p>}
+            </div>
+
+            <div className="flex items-center gap-2">
+              <Button size="sm" onClick={() => void run()} disabled={runDisabled}>
+                {loading ? <Loader2 size={13} className="mr-1.5 animate-spin" /> : <PlayCircle size={13} className="mr-1.5" />}
+                {loading ? t('playground.run.running') : t('playground.run.label')}
+              </Button>
+              {loading && <span className="text-[11px] text-muted-foreground">{t('playground.run.waitHint')}</span>}
+            </div>
+
+            {errorKind && (
+              <div className="flex items-start gap-2 rounded-md bg-red-500/10 px-3 py-2 text-xs text-red-600 dark:text-red-300">
+                <AlertTriangle size={13} className="mt-0.5 shrink-0" /> {t(`playground.errors.${errorKind}`)}
+              </div>
+            )}
+          </div>
+
+          {/* Right column: result */}
+          <div className="flex min-h-0 flex-col gap-3 md:overflow-y-auto md:pl-1">
+            <div className={cn('flex min-h-0 flex-col gap-1.5', mode === 'rule' ? 'flex-[3]' : 'flex-1')}>
+              <label className="block text-xs font-medium text-foreground/80">{t('playground.result.label')}</label>
+              <div className="min-h-0 flex-1">
+                <ParsedEventView event={result?.event} loading={loading} elapsedMs={elapsedMs ?? undefined} />
+              </div>
+            </div>
+            {mode === 'rule' && (
+              <div className="flex min-h-0 flex-[2] flex-col gap-1.5">
+                <label className="block text-xs font-medium text-foreground/80">{t('playground.alerts.label')}</label>
+                <div className="min-h-0 flex-1">
+                  <AlertsListView alerts={result?.alerts} loading={loading} />
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/playground/lib/event-fields.ts
+++ b/frontend/src/features/playground/lib/event-fields.ts
@@ -1,0 +1,45 @@
+/**
+ * Field-flattening and severity-styling helpers shared by the playground's
+ * result views (`ParsedEventView` for the parsed event, `AlertsListView` for
+ * triggered alerts). Extracted from `ParsedEventView` so both views render
+ * fields identically — intentionally not shared with log-explorer's own
+ * flattening so the playground can evolve independently for testing purposes.
+ */
+
+/** Flattens a nested object into dotted-path key/value pairs, e.g.
+ * `{ origin: { ip: '1.2.3.4' } }` → `{ 'origin.ip': '1.2.3.4' }`. */
+export function flatten(obj: unknown, prefix = '', out: Record<string, unknown> = {}): Record<string, unknown> {
+  if (obj && typeof obj === 'object' && !Array.isArray(obj)) {
+    for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
+      const key = prefix ? `${prefix}.${k}` : k
+      if (v && typeof v === 'object' && !Array.isArray(v)) flatten(v, key, out)
+      else out[key] = Array.isArray(v) ? v.join(', ') : v
+    }
+  }
+  return out
+}
+
+// Fields that duplicate what's already visible in the "Raw log" input on the
+// left — showing the full raw string again inside the field grid wrecks its
+// rhythm (one giant multi-line cell among dozens of short ones) for zero gain.
+export const HIDDEN_FIELDS = new Set(['raw'])
+
+// Same severity/level palette already used across the product (see
+// alerts/lib/alert-meta.ts SEV_META and log-explorer's LEVEL_TONE) — kept
+// local here since the playground is intentionally self-contained.
+export const SEVERITY_TONE: Record<string, string> = {
+  critical: 'bg-red-500/15 text-red-600 ring-1 ring-inset ring-red-500/30 dark:text-red-300',
+  high: 'bg-red-500/15 text-red-600 ring-1 ring-inset ring-red-500/30 dark:text-red-300',
+  error: 'bg-orange-500/15 text-orange-600 ring-1 ring-inset ring-orange-500/30 dark:text-orange-300',
+  medium: 'bg-amber-500/15 text-amber-600 ring-1 ring-inset ring-amber-500/30 dark:text-amber-300',
+  warning: 'bg-amber-500/15 text-amber-600 ring-1 ring-inset ring-amber-500/30 dark:text-amber-300',
+  warn: 'bg-amber-500/15 text-amber-600 ring-1 ring-inset ring-amber-500/30 dark:text-amber-300',
+  low: 'bg-sky-500/15 text-sky-600 ring-1 ring-inset ring-sky-500/30 dark:text-sky-300',
+  info: 'bg-sky-500/15 text-sky-600 ring-1 ring-inset ring-sky-500/30 dark:text-sky-300',
+  debug: 'bg-muted text-muted-foreground ring-1 ring-inset ring-border',
+}
+
+export function isSeverityField(key: string): boolean {
+  const last = key.split('.').pop() ?? key
+  return /(severity|level)$/i.test(last)
+}

--- a/frontend/src/features/playground/services/playground-http.service.ts
+++ b/frontend/src/features/playground/services/playground-http.service.ts
@@ -1,0 +1,14 @@
+import { ApiError, createApiClient } from '@/shared/lib/api-client'
+import type { TestFilterRequest, TestFilterResponse, TestRuleRequest, TestRuleResponse } from '../types'
+
+const api = createApiClient()
+
+export { ApiError as PlaygroundHttpError }
+
+// Shared playground routes live under the eventprocessing module group.
+const BASE = '/eventprocessing/playground'
+
+export const playgroundHttpService = {
+  testFilter: (req: TestFilterRequest) => api.post<TestFilterResponse>(`${BASE}/test-filter`, req),
+  testRule: (req: TestRuleRequest) => api.post<TestRuleResponse>(`${BASE}/test-rule`, req),
+}

--- a/frontend/src/features/playground/types.ts
+++ b/frontend/src/features/playground/types.ts
@@ -1,0 +1,44 @@
+/**
+ * Shared types for the parsing-filter/correlation-rule "playground" — a
+ * one-shot test of a raw log against either the live (deployed) pipeline
+ * or an unsaved draft, without persisting anything.
+ */
+export type PlaygroundMode = 'filter' | 'rule'
+
+export interface PlaygroundLog {
+  dataType: string
+  raw: string
+}
+
+export interface PlaygroundFilterInput {
+  content: string
+}
+
+export interface TestFilterRequest {
+  log: PlaygroundLog
+  /** Present when testing an unsaved draft; omitted to test the live pipeline. */
+  filter?: PlaygroundFilterInput
+}
+
+export interface TestFilterResponse {
+  uuid: string
+  /** The parsed event, when the pipeline produced one. */
+  event?: Record<string, unknown>
+  alerts: unknown[]
+  stopReason?: string
+  timedOut: boolean
+}
+
+export interface PlaygroundRuleInput {
+  content: string
+}
+
+export interface TestRuleRequest {
+  log: PlaygroundLog
+  /** Present when testing an unsaved draft; omitted to test all deployed rules. */
+  rule?: PlaygroundRuleInput
+}
+
+/** Backend returns the same `PlaygroundResponse` DTO for both test-filter and
+ * test-rule — `TestRule` just also populates `alerts`. */
+export type TestRuleResponse = TestFilterResponse

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -4516,6 +4516,7 @@
       "content": "Content (pipeline YAML)",
       "contentHint": "A valid pipeline: YAML definition.",
       "readOnly": "System pipeline — read-only. You can only enable or disable it.",
+      "test": "Test",
       "save": "Save",
       "saving": "Saving…",
       "delete": "Delete",
@@ -4566,12 +4567,60 @@
       "paramsKey": "Key",
       "paramsValue": "Value"
     },
-    "allDataTypes": "All data types"
+    "allDataTypes": "All data types",
+    "testPipeline": "Test pipeline"
+  },
+  "playground": {
+    "title": "Test pipeline",
+    "noDataTypes": "This pipeline has no data types assigned yet — add one to test it.",
+    "dataTypeLabel": "Data type",
+    "dataTypePlaceholder": "No data types available",
+    "dataTypeSingleHint": "This pipeline only has one data type — add more to choose between them.",
+    "rawLogLabel": "Raw log",
+    "rawLogPlaceholder": "Paste a sample raw log line…",
+    "rawLogCounter": "{{chars}} chars · {{kb}} KB",
+    "rawLogTooLarge": "This log exceeds the 1 MB limit — trim it before running the test.",
+    "run": {
+      "label": "Run",
+      "running": "Testing…",
+      "waitHint": "This can take up to 15 seconds while the pipeline processes the log."
+    },
+    "errors": {
+      "busy": "The playground is busy running another test — please try again shortly.",
+      "timeout": "The test timed out — this usually means the selected data type doesn't match the log format.",
+      "validation": "The request was invalid — check the raw log and pipeline content.",
+      "server": "The playground couldn't complete the test — please try again."
+    },
+    "result": {
+      "label": "Parsed result",
+      "empty": "Run a test to see the parsed event here.",
+      "loading": "Waiting for the parsed event…",
+      "tabs": {
+        "fields": "Fields",
+        "json": "JSON"
+      },
+      "fieldsCount_one": "{{count}} field",
+      "fieldsCount_other": "{{count}} fields",
+      "copy": "Copy",
+      "copied": "Copied",
+      "elapsed": "Parsed in {{time}}",
+      "elapsedHint": "Time from Run to the parsed result",
+      "searchPlaceholder": "Search fields…",
+      "noMatch": "No fields match your search."
+    },
+    "alerts": {
+      "label": "Alerts",
+      "empty": "Run a test to see any resulting alerts here.",
+      "none": "No alerts were triggered.",
+      "count_one": "{{count}} alert",
+      "count_other": "{{count}} alerts"
+    }
   },
   "alertingRules": {
     "title": "Alerting Rules",
     "subtitle": "Correlation rules that turn events into alerts. Toggle, tune or author your own.",
     "new": "New rule",
+    "test": "Test",
     "refresh": "Refresh",
     "empty": "No rules match.",
     "loadError": "Could not load the rules.",
@@ -4626,6 +4675,7 @@
       "delete": "Delete",
       "cancel": "Cancel",
       "save": "Save",
+      "test": "Test",
       "metadata": "Metadata",
       "name": "Name",
       "confidentiality": "Confidentiality",


### PR DESCRIPTION
## What changed

Wires up the backend's `test-filter` and `test-rule` playground endpoints (already deployed, unused until now) to the UI:

- New shared `features/playground/` module: types, HTTP service, a result view (`ParsedEventView`) that renders a tested log's parsed fields exactly like Log Explorer would, an `AlertsListView` for rule-mode results, and one shared `TestPlaygroundModal` for both modes.
- **Pipelines** (`parsing-filters`): "Test pipeline" button in the list header (tests a raw log against the currently deployed filters) and a "Test" button inside the pipeline drawer (tests the unsaved draft — create, edit, or read-only system pipelines).
- **Alerting Rules**: same pattern — "Test" in the list header (tests against all deployed rules) and "Test" inside the rule drawer/view (tests the unsaved draft, including read-only system rules), using `ruleFormToYaml` to convert the form into the same YAML the backend evaluates.

## Why

Editors of filters and correlation rules had no way to validate a change before saving it — errors only surfaced after deploy, against real traffic. This lets them paste a sample raw log and see exactly how it would parse (and, for rules, whether it would fire) before committing anything.

