### PR TITLE
Add actionResult mapping for GCP DNS and HTTP request logs

### DIFF
--- a/filters/google/gcp.yml
+++ b/filters/google/gcp.yml
@@ -486,6 +486,51 @@ pipeline:
             value: "failed"
           where: 'exists("log.protoPayloadMethodName") && greaterThan("log.protoPayloadStatusCode", 0)'
 
+      # Adding actionResult for Cloud DNS query logs (dns.googleapis.com).
+      - add:
+          function: "string"
+          params:
+            key: actionResult
+            value: "success"
+          where: '!exists("actionResult") && equals("log.jsonPayloadResponseCode", "NOERROR")'
+
+      - add:
+          function: "string"
+          params:
+            key: actionResult
+            value: "denied"
+          where: '!exists("actionResult") && equals("log.jsonPayloadResponseCode", "REFUSED")'
+
+      - add:
+          function: "string"
+          params:
+            key: actionResult
+            value: "failed"
+          where: '!exists("actionResult") && exists("log.jsonPayloadResponseCode")'
+
+      # Adding actionResult for plain HTTP request logs (Cloud Run, Load
+      # Balancer, Cloud Functions, App Engine, etc.).
+      - add:
+          function: "string"
+          params:
+            key: actionResult
+            value: "success"
+          where: 'exists("statusCode") && !exists("actionResult") && lessThan("statusCode", 400)'
+
+      - add:
+          function: "string"
+          params:
+            key: actionResult
+            value: "denied"
+          where: 'exists("statusCode") && !exists("actionResult") && oneOf("statusCode", [401, 403])'
+
+      - add:
+          function: "string"
+          params:
+            key: actionResult
+            value: "failed"
+          where: 'exists("statusCode") && !exists("actionResult") && greaterOrEqual("statusCode", 400)'
+
       # Adding geolocation to origin.ip
       - dynamic:
           plugin: com.utmstack.geolocation


### PR DESCRIPTION
## What this PR does

Adds actionResult mapping in the GCP filter for two log families that were previously indexed without that field:
- Cloud DNS query logs (dns.googleapis.com/dns_queries): maps jsonPayload.responseCode to actionResult:
- NOERROR → success
- REFUSED → denied
- any other response code (NXDOMAIN, SERVFAIL, FORMERR, NOTIMP, ...) → failed

Cloud Run / Load Balancer / App Engine / Cloud Functions HTTP request logs (which carry httpRequest.status renamed as statusCode):
- 1xx–3xx → success
- 401 and 403 → denied (access denial, distinct from generic failure)
- remaining 4xx and 5xx → failed

## Related issue
N/A