### PR TITLE
Backlog/v12 forwarder collector fixes

### DIFF
--- a/collectors/forwarder/collector/collector.go
+++ b/collectors/forwarder/collector/collector.go
@@ -3,6 +3,7 @@ package collector
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/threatwinds/go-sdk/plugins"
 	"github.com/utmstack/UTMStack/collectors/forwarder/collector/file"
@@ -19,52 +20,54 @@ type Collector interface {
 	Stop()
 }
 
-var (
-	activeCollectors []Collector
-	collectorsMu     sync.Mutex
+const watchQuiesceTimeout = 10 * time.Second
 
-	// LogQueue is the shared channel that all collectors push logs to.
-	LogQueue chan *plugins.Log
+type collectorHandle struct {
+	collector Collector
+	done      chan struct{}
+}
+
+var (
+	activeCollectors []collectorHandle
+	collectorsMu     sync.Mutex
+	cancelWatchers   context.CancelFunc
+	LogQueue         chan *plugins.Log
 )
 
 func init() {
 	LogQueue = make(chan *plugins.Log, 1000)
 }
 
-// StartAll starts all collectors: syslog, netflow, file, and http.
-// The context is used for graceful shutdown signaling.
 func StartAll(ctx context.Context) {
+	startAll(ctx, LogQueue,
+		syslog.New(),
+		netflow.New(),
+		file.New(),
+		http.New(),
+	)
+}
+
+func startAll(ctx context.Context, queue chan *plugins.Log, collectors ...Collector) {
 	collectorsMu.Lock()
 	defer collectorsMu.Unlock()
 
 	// Clear previous collectors
 	activeCollectors = nil
 
-	// Create syslog collector
-	syslogCollector := syslog.New()
-	activeCollectors = append(activeCollectors, syslogCollector)
-	go runCollector(ctx, syslogCollector, LogQueue)
+	watchCtx, cancel := context.WithCancel(ctx)
+	cancelWatchers = cancel
 
-	// Create netflow collector
-	netflowCollector := netflow.New()
-	activeCollectors = append(activeCollectors, netflowCollector)
-	go runCollector(ctx, netflowCollector, LogQueue)
-
-	// Create file collector (nginx, postgresql, etc.)
-	fileCollector := file.New()
-	activeCollectors = append(activeCollectors, fileCollector)
-	go runCollector(ctx, fileCollector, LogQueue)
-
-	// Create HTTP/HTTPS collector
-	httpColl := http.New()
-	activeCollectors = append(activeCollectors, httpColl)
-	go runCollector(ctx, httpColl, LogQueue)
+	for _, c := range collectors {
+		handle := collectorHandle{collector: c, done: make(chan struct{})}
+		activeCollectors = append(activeCollectors, handle)
+		go runCollector(watchCtx, c, queue, handle.done)
+	}
 
 	utils.Logger.Info("All collectors started")
 }
 
-// runCollector runs a collector with panic recovery.
-func runCollector(ctx context.Context, c Collector, queue chan *plugins.Log) {
+func runCollector(ctx context.Context, c Collector, queue chan *plugins.Log, done chan struct{}) {
+	defer close(done)
 	defer func() {
 		if r := recover(); r != nil {
 			utils.Logger.ErrorF("panic in collector %s: %v", c.Name(), r)
@@ -75,13 +78,68 @@ func runCollector(ctx context.Context, c Collector, queue chan *plugins.Log) {
 
 // StopAll stops all active collectors.
 func StopAll() {
+	stopAll(watchQuiesceTimeout)
+}
+
+func stopAll(timeout time.Duration) {
 	collectorsMu.Lock()
 	defer collectorsMu.Unlock()
 
-	for _, c := range activeCollectors {
-		utils.Logger.Info("Stopping collector: %s", c.Name())
-		c.Stop()
+	if cancelWatchers != nil {
+		cancelWatchers()
+		cancelWatchers = nil
+	}
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	timedOut := false
+
+	// Wait for every watch loop to quiesce before stopping anything, so no
+	// reconcile can reopen a socket behind Stop. The timer is shared, so the
+	// bound covers this whole phase instead of each collector separately.
+	//
+	// On expiry the ordering guarantee no longer holds: Stop then runs on a
+	// collector whose reconcile may still be in flight, which is exactly the
+	// race this phase exists to prevent. Doing it anyway is deliberate, because
+	// leaving a collector alive is worse, but it is a degraded path.
+	for _, handle := range activeCollectors {
+		// Check without blocking first. A collector that already returned must
+		// never be reported as late, and it could be if the timer is also ready,
+		// because select picks at random when several cases are ready.
+		select {
+		case <-handle.done:
+			continue
+		default:
+		}
+
+		if timedOut {
+			utils.Logger.ErrorF("collector %s did not stop watching within %v, stopping it anyway", handle.collector.Name(), timeout)
+			continue
+		}
+
+		select {
+		case <-handle.done:
+		case <-timer.C:
+			timedOut = true
+			// done may have closed while we were blocked here; confirm before
+			// reporting this collector as late.
+			select {
+			case <-handle.done:
+			default:
+				utils.Logger.ErrorF("collector %s did not stop watching within %v, stopping it anyway", handle.collector.Name(), timeout)
+			}
+		}
+	}
+
+	for _, handle := range activeCollectors {
+		utils.Logger.Info("Stopping collector: %s", handle.collector.Name())
+		handle.collector.Stop()
 	}
 	activeCollectors = nil
+
+	if timedOut {
+		utils.Logger.ErrorF("all collectors stopped, but at least one did not quiesce within %v", timeout)
+		return
+	}
 	utils.Logger.Info("All collectors stopped")
 }

--- a/collectors/forwarder/collector/collector.go
+++ b/collectors/forwarder/collector/collector.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/threatwinds/go-sdk/plugins"
 	"github.com/utmstack/UTMStack/collectors/forwarder/collector/file"
+	"github.com/utmstack/UTMStack/collectors/forwarder/collector/http"
 	"github.com/utmstack/UTMStack/collectors/forwarder/collector/netflow"
 	"github.com/utmstack/UTMStack/collectors/forwarder/collector/syslog"
-	listeners "github.com/utmstack/UTMStack/collectors/forwarder/listeners"
 	"github.com/utmstack/UTMStack/collectors/forwarder/utils"
 )
 
@@ -56,7 +56,7 @@ func StartAll(ctx context.Context) {
 	go runCollector(ctx, fileCollector, LogQueue)
 
 	// Create HTTP/HTTPS collector
-	httpColl := listeners.New()
+	httpColl := http.New()
 	activeCollectors = append(activeCollectors, httpColl)
 	go runCollector(ctx, httpColl, LogQueue)
 
@@ -85,5 +85,3 @@ func StopAll() {
 	activeCollectors = nil
 	utils.Logger.Info("All collectors stopped")
 }
-
-

--- a/collectors/forwarder/collector/config.go
+++ b/collectors/forwarder/collector/config.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/utmstack/UTMStack/collectors/forwarder/collector/http"
 	"github.com/utmstack/UTMStack/collectors/forwarder/collector/schema"
 	"github.com/utmstack/UTMStack/collectors/forwarder/config"
-	listeners "github.com/utmstack/UTMStack/collectors/forwarder/listeners"
 	"github.com/utmstack/UTMStack/collectors/forwarder/utils"
 	"github.com/utmstack/UTMStack/shared/fs"
 )
@@ -390,7 +390,7 @@ func EnableHTTPIntegration(logTyp string, opts HTTPIntegrationOptions) (string, 
 		tp := filepath.Join(config.HTTPTokenDir, "integration-http-"+logTyp+".token")
 		if _, statErr := os.Stat(tp); statErr != nil {
 			// Generate token when file doesn't exist or can't be read
-			token, genErr := listeners.GenerateTokenFile(tp)
+			token, genErr := http.GenerateTokenFile(tp)
 			if genErr != nil {
 				return "", fmt.Errorf("generate token: %w", genErr)
 			}

--- a/collectors/forwarder/collector/configwatcher/watcher.go
+++ b/collectors/forwarder/collector/configwatcher/watcher.go
@@ -11,15 +11,24 @@ import (
 	"github.com/utmstack/UTMStack/collectors/forwarder/utils"
 )
 
-const (
-	// FallbackInterval is used as a safety net in case fsnotify misses events
-	FallbackInterval = 5 * time.Minute
-)
+// FallbackInterval is used as a safety net in case fsnotify misses events.
+const FallbackInterval = 5 * time.Minute
 
-// Watch monitors the collector config file for changes and calls onConfigChange
-// when the file is modified. It also calls onConfigChange periodically as a fallback.
-// This function blocks until ctx is cancelled.
+// Watch blocks until ctx is cancelled. collector.StopAll depends on that: the
+// return of a collector's Start is its signal that no reconcile is still in
+// flight. An implementation that returned early while the loop kept running in
+// the background would silently reintroduce the shutdown race.
 func Watch(ctx context.Context, name string, onConfigChange func()) {
+	// Check without blocking whether we were cancelled before doing any work:
+	// the initial onConfigChange below opens sockets, and a collector whose
+	// goroutine had not been scheduled yet when StopAll ran must not open them.
+	select {
+	case <-ctx.Done():
+		utils.Logger.Info("%s: stopping config watcher", name)
+		return
+	default:
+	}
+
 	// Initial call
 	onConfigChange()
 

--- a/collectors/forwarder/collector/file/file.go
+++ b/collectors/forwarder/collector/file/file.go
@@ -23,8 +23,6 @@ const pollInterval = 1 * time.Second
 type fileWatcher struct {
 	dataType string
 	path     string
-	file     *os.File
-	offset   int64
 	cancel   context.CancelFunc
 }
 
@@ -52,9 +50,6 @@ func (fc *FileCollector) Stop() {
 	for key, w := range fc.watchers {
 		if w.cancel != nil {
 			w.cancel()
-		}
-		if w.file != nil {
-			w.file.Close()
 		}
 		delete(fc.watchers, key)
 	}
@@ -121,9 +116,6 @@ func (fc *FileCollector) reconcile(ctx context.Context) {
 			if w.cancel != nil {
 				w.cancel()
 			}
-			if w.file != nil {
-				w.file.Close()
-			}
 			delete(fc.watchers, key)
 		}
 	}
@@ -145,9 +137,6 @@ func (fc *FileCollector) stopWatchersForDataType(dataType string) {
 			utils.Logger.Info("file collector: stopping watcher for %s", key)
 			if w.cancel != nil {
 				w.cancel()
-			}
-			if w.file != nil {
-				w.file.Close()
 			}
 			delete(fc.watchers, key)
 		}
@@ -184,6 +173,14 @@ func (fc *FileCollector) tailFile(ctx context.Context, w *fileWatcher) {
 		hostname = "unknown"
 	}
 
+	var file *os.File
+	var offset int64
+	defer func() {
+		if file != nil {
+			file.Close()
+		}
+	}()
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -192,54 +189,54 @@ func (fc *FileCollector) tailFile(ctx context.Context, w *fileWatcher) {
 		}
 
 		// Open the file if not already open or if it was rotated
-		if w.file == nil {
-			file, err := os.Open(w.path)
+		if file == nil {
+			opened, err := os.Open(w.path)
 			if err != nil {
 				utils.Logger.LogF(100, "file collector: error opening %s: %v", w.path, err)
 				time.Sleep(pollInterval)
 				continue
 			}
-			w.file = file
+			file = opened
 
 			// Seek to end to only read new content
-			offset, err := file.Seek(0, io.SeekEnd)
+			end, err := file.Seek(0, io.SeekEnd)
 			if err != nil {
 				utils.Logger.ErrorF("file collector: error seeking %s: %v", w.path, err)
-				w.file.Close()
-				w.file = nil
+				file.Close()
+				file = nil
 				time.Sleep(pollInterval)
 				continue
 			}
-			w.offset = offset
+			offset = end
 		}
 
 		// Check for file rotation (file was replaced)
 		stat, err := os.Stat(w.path)
 		if err != nil {
 			// File may have been deleted, close and retry
-			w.file.Close()
-			w.file = nil
+			file.Close()
+			file = nil
 			time.Sleep(pollInterval)
 			continue
 		}
 
-		fileStat, err := w.file.Stat()
+		fileStat, err := file.Stat()
 		if err != nil || !os.SameFile(stat, fileStat) {
 			// File was rotated, reopen
-			w.file.Close()
-			w.file = nil
-			w.offset = 0
+			file.Close()
+			file = nil
+			offset = 0
 			continue
 		}
 
 		// Check if file was truncated
-		if stat.Size() < w.offset {
-			w.offset = 0
-			w.file.Seek(0, io.SeekStart)
+		if stat.Size() < offset {
+			offset = 0
+			file.Seek(0, io.SeekStart)
 		}
 
 		// Read new lines
-		reader := bufio.NewReader(w.file)
+		reader := bufio.NewReader(file)
 		for {
 			select {
 			case <-ctx.Done():
@@ -260,7 +257,7 @@ func (fc *FileCollector) tailFile(ctx context.Context, w *fileWatcher) {
 			}
 
 			// Update offset
-			w.offset += int64(len(line))
+			offset += int64(len(line))
 
 			// Validate and send log
 			validatedLog, _, err := entities.ValidateString(line, false)

--- a/collectors/forwarder/collector/http/auth.go
+++ b/collectors/forwarder/collector/http/auth.go
@@ -1,4 +1,4 @@
-package listeners
+package http
 
 import (
 	"crypto/hmac"

--- a/collectors/forwarder/collector/http/handler.go
+++ b/collectors/forwarder/collector/http/handler.go
@@ -1,4 +1,4 @@
-package listeners
+package http
 
 import (
 	"io"

--- a/collectors/forwarder/collector/http/http.go
+++ b/collectors/forwarder/collector/http/http.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	stdhttp "net/http"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -24,7 +25,7 @@ type HTTPCollector struct {
 	ctx       context.Context
 }
 
-type httpInstance struct {
+type httpConfig struct {
 	dataType        string
 	proto           string // "http" | "https"
 	port            string
@@ -33,8 +34,13 @@ type httpInstance struct {
 	auth            string // "" | "bearer" | "hmac"
 	signatureHeader string // e.g. "X-Hub-Signature-256"
 	tokenPath       string // path to token file (used by bearer and hmac)
-	server          *stdhttp.Server
-	listener        net.Listener
+}
+
+type httpInstance struct {
+	httpConfig
+
+	server   *stdhttp.Server
+	listener net.Listener
 }
 
 func New() *HTTPCollector {
@@ -74,29 +80,53 @@ func (h *HTTPCollector) reconcile() {
 	for name, integration := range cfg.Integrations {
 		if integration.HTTP != nil && integration.HTTP.Enabled {
 			key := name + ":http"
-			desired[key] = buildInstance(name, "http", integration.HTTP)
+			inst, err := buildInstance(name, "http", integration.HTTP)
+			if err != nil {
+				utils.Logger.ErrorF("http: skipping integration %s: %v", key, err)
+			} else {
+				desired[key] = inst
+			}
 		}
 		if integration.HTTPS != nil && integration.HTTPS.Enabled {
 			key := name + ":https"
-			desired[key] = buildInstance(name, "https", integration.HTTPS)
+			inst, err := buildInstance(name, "https", integration.HTTPS)
+			if err != nil {
+				utils.Logger.ErrorF("http: skipping integration %s: %v", key, err)
+			} else {
+				desired[key] = inst
+			}
 		}
 	}
 
-	for key, inst := range h.instances {
-		if _, ok := desired[key]; !ok {
-			shutdownInstance(inst)
-			delete(h.instances, key)
+	// Everything that must change goes down before anything comes up.
+	// Shutting down and restarting one key at a time cannot handle two
+	// integrations swapping ports: whichever is processed first fails to bind
+	// because the other still holds the port, and stays down until the next
+	// reconcile.
+	for key, running := range h.instances {
+		inst, wanted := desired[key]
+		// Compare the whole config: a presence check silently ignores port,
+		// path and auth edits. New fields must go in httpConfig, not here.
+		if wanted && running.httpConfig == inst.httpConfig {
+			continue
 		}
+		if wanted {
+			utils.Logger.Info("http[%s]: configuration changed, restarting on %s:%s%s (auth=%q)",
+				key, inst.bind, inst.port, inst.path, inst.auth)
+		}
+		shutdownInstance(running)
+		delete(h.instances, key)
 	}
 
 	for key, inst := range desired {
-		if _, running := h.instances[key]; !running {
-			if err := h.startInstance(inst); err != nil {
-				utils.Logger.ErrorF("http: failed to start %s: %v", key, err)
-				continue
-			}
-			h.instances[key] = inst
+		if _, isRunning := h.instances[key]; isRunning {
+			continue
 		}
+		if err := h.startInstance(inst); err != nil {
+			utils.Logger.ErrorF("http: failed to start %s: %v", key, err)
+			continue
+		}
+		h.instances[key] = inst
 	}
 }
 
@@ -149,18 +179,65 @@ func shutdownInstance(inst *httpInstance) {
 		defer cancel()
 		if err := inst.server.Shutdown(ctx); err != nil {
 			utils.Logger.ErrorF("http[%s:%s]: shutdown error: %v", inst.dataType, inst.proto, err)
+			if err := inst.server.Close(); err != nil {
+				utils.Logger.ErrorF("http[%s:%s]: force close error: %v", inst.dataType, inst.proto, err)
+			}
 		}
 	}
 }
 
-func buildInstance(name, proto string, port *schema.HTTPPort) *httpInstance {
+// defaultPath is used when the operator leaves the path empty.
+const defaultPath = "/logs"
+
+func normalizeAndValidatePath(path string) (normalized string, repaired bool, err error) {
+	if path == "" {
+		return defaultPath, false, nil
+	}
+
+	normalized = strings.TrimSpace(path)
+	if normalized == "" {
+		normalized = defaultPath
+	}
+
+	if i := strings.IndexAny(normalized, " \t"); i >= 0 {
+		return "", false, fmt.Errorf("invalid path %q: contains whitespace at offset %d; "+
+			"a URL path cannot contain a space or tab, and method-scoped patterns such as %q are not supported",
+			path, i, "GET /logs")
+	}
+
+	if !strings.HasPrefix(normalized, "/") {
+		normalized = "/" + normalized
+	}
+
+	if err := probeMuxPattern(normalized); err != nil {
+		return "", false, fmt.Errorf("invalid path %q: %w", path, err)
+	}
+
+	return normalized, normalized != path, nil
+}
+
+func probeMuxPattern(pattern string) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("rejected by http.ServeMux: %v", r)
+		}
+	}()
+	stdhttp.NewServeMux().Handle(pattern, stdhttp.NotFoundHandler())
+	return nil
+}
+
+func buildInstance(name, proto string, port *schema.HTTPPort) (*httpInstance, error) {
 	bind := port.Bind
 	if bind == "" {
 		bind = "127.0.0.1"
 	}
-	path := port.Path
-	if path == "" {
-		path = "/logs"
+	path, repaired, err := normalizeAndValidatePath(port.Path)
+	if err != nil {
+		return nil, err
+	}
+	if repaired {
+		utils.Logger.Info("http[%s:%s]: path %q is malformed and was read as %q; fix the integration configuration",
+			name, proto, port.Path, path)
 	}
 	sigHeader := port.SignatureHeader
 	if sigHeader == "" {
@@ -168,15 +245,17 @@ func buildInstance(name, proto string, port *schema.HTTPPort) *httpInstance {
 	}
 
 	return &httpInstance{
-		dataType:        name,
-		proto:           proto,
-		port:            port.Port,
-		path:            path,
-		bind:            bind,
-		auth:            port.Auth,
-		signatureHeader: sigHeader,
-		tokenPath:       tokenPath(name),
-	}
+		httpConfig: httpConfig{
+			dataType:        name,
+			proto:           proto,
+			port:            port.Port,
+			path:            path,
+			bind:            bind,
+			auth:            port.Auth,
+			signatureHeader: sigHeader,
+			tokenPath:       tokenPath(name),
+		},
+	}, nil
 }
 
 func tokenPath(name string) string {

--- a/collectors/forwarder/collector/http/http.go
+++ b/collectors/forwarder/collector/http/http.go
@@ -1,4 +1,4 @@
-package listeners
+package http
 
 import (
 	"context"

--- a/collectors/forwarder/collector/netflow/netflow.go
+++ b/collectors/forwarder/collector/netflow/netflow.go
@@ -225,12 +225,15 @@ func (nc *NetflowCollector) enablePort() {
 		return
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
+	portStr := nc.port
+
 	nc.isEnabled = true
 	nc.listener = listener
-	nc.ctx, nc.cancel = context.WithCancel(context.Background())
+	nc.ctx, nc.cancel = ctx, cancel
 	nc.mu.Unlock()
 
-	utils.Logger.Info("Server %s listening in port: %s protocol: UDP", nc.dataType, nc.port)
+	utils.Logger.Info("Server %s listening in port: %s protocol: UDP", nc.dataType, portStr)
 
 	buffer := make([]byte, 65535)
 
@@ -243,12 +246,12 @@ func (nc *NetflowCollector) enablePort() {
 
 		for {
 			select {
-			case <-nc.ctx.Done():
+			case <-ctx.Done():
 				return
 			default:
-				nc.listener.SetDeadline(time.Now().Add(1 * time.Second))
+				listener.SetDeadline(time.Now().Add(1 * time.Second))
 
-				length, addr, err := nc.listener.ReadFromUDP(buffer)
+				length, addr, err := listener.ReadFromUDP(buffer)
 				if err != nil {
 					if errors.Is(err, net.ErrClosed) {
 						return

--- a/collectors/forwarder/collector/syslog/framing.go
+++ b/collectors/forwarder/collector/syslog/framing.go
@@ -6,8 +6,6 @@ import (
 	"io"
 	"strconv"
 	"strings"
-
-	"github.com/utmstack/UTMStack/collectors/forwarder/utils"
 )
 
 // Buffer size constants for syslog message processing.
@@ -30,7 +28,6 @@ const (
 func detectFramingMethod(reader *bufio.Reader) (FramingMethod, error) {
 	firstByte, err := reader.Peek(1)
 	if err != nil {
-		utils.Logger.ErrorF("failed to peek first byte for framing detection: %v", err)
 		return 0, fmt.Errorf("failed to peek first byte: %w", err)
 	}
 
@@ -42,7 +39,6 @@ func detectFramingMethod(reader *bufio.Reader) (FramingMethod, error) {
 		return FramingNewline, nil
 	}
 
-	utils.Logger.ErrorF("unknown framing method detected, first byte: 0x%02x", firstByte[0])
 	return 0, fmt.Errorf("unknown framing method, first byte: 0x%02x", firstByte[0])
 }
 
@@ -50,30 +46,25 @@ func detectFramingMethod(reader *bufio.Reader) (FramingMethod, error) {
 func readOctetCountingFrame(reader *bufio.Reader) (string, error) {
 	lengthStr, err := reader.ReadString(' ')
 	if err != nil {
-		utils.Logger.ErrorF("failed to read message length in octet counting frame: %v", err)
 		return "", fmt.Errorf("failed to read message length: %w", err)
 	}
 
 	lengthStr = strings.TrimSuffix(lengthStr, " ")
 	msgLen, err := strconv.Atoi(lengthStr)
 	if err != nil {
-		utils.Logger.ErrorF("invalid message length '%s' in octet counting frame: %v", lengthStr, err)
 		return "", fmt.Errorf("invalid message length '%s': %w", lengthStr, err)
 	}
 
 	if msgLen < 1 {
-		utils.Logger.ErrorF("message length %d is too small (minimum 1 byte)", msgLen)
 		return "", fmt.Errorf("message length %d is too small (minimum 1)", msgLen)
 	}
 	if msgLen > MaxBufferSize {
-		utils.Logger.ErrorF("message length %d exceeds maximum %d bytes", msgLen, MaxBufferSize)
 		return "", fmt.Errorf("message length %d exceeds maximum %d", msgLen, MaxBufferSize)
 	}
 
 	msgBytes := make([]byte, msgLen)
 	_, err = io.ReadFull(reader, msgBytes)
 	if err != nil {
-		utils.Logger.ErrorF("failed to read %d byte message body: %v", msgLen, err)
 		return "", fmt.Errorf("failed to read %d byte message body: %w", msgLen, err)
 	}
 
@@ -84,7 +75,6 @@ func readOctetCountingFrame(reader *bufio.Reader) (string, error) {
 func readNewlineFrame(reader *bufio.Reader) (string, error) {
 	message, err := reader.ReadString('\n')
 	if err != nil {
-		utils.Logger.ErrorF("failed to read newline-delimited message: %v", err)
 		return "", fmt.Errorf("failed to read newline-delimited message: %w", err)
 	}
 	return message, nil
@@ -103,7 +93,6 @@ func readSyslogMessage(reader *bufio.Reader) (string, error) {
 	case FramingNewline:
 		return readNewlineFrame(reader)
 	default:
-		utils.Logger.ErrorF("unsupported framing method: %d", method)
 		return "", fmt.Errorf("unsupported framing method: %d", method)
 	}
 }

--- a/collectors/forwarder/collector/syslog/handler.go
+++ b/collectors/forwarder/collector/syslog/handler.go
@@ -60,9 +60,15 @@ func (inst *syslogInstance) readLoop(ctx context.Context, reader *bufio.Reader, 
 				utils.Logger.ErrorF("error reading %s data from %s: %v", connType, remoteAddr, err)
 				return
 			}
-			msgChannel <- MSGDS{
+			// msgChannel is unbuffered and handleMessage returns on ctx.Done,
+			// so an unguarded send parks here forever and leaks the connection.
+			select {
+			case <-ctx.Done():
+				return
+			case msgChannel <- MSGDS{
 				DataSource: remoteAddr,
 				Message:    message,
+			}:
 			}
 		}
 	}
@@ -93,6 +99,16 @@ func (inst *syslogInstance) handleConnectionTCP(ctx context.Context, c net.Conn,
 	// Reset deadline and create a new reader that includes the read bytes
 	c.SetReadDeadline(time.Time{})
 	reader = bufio.NewReader(io.MultiReader(strings.NewReader(string(firstBytes[:n])), reader))
+
+	handlerDone := make(chan struct{})
+	defer close(handlerDone)
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = c.SetReadDeadline(time.Now())
+		case <-handlerDone:
+		}
+	}()
 
 	msgChannel := make(chan MSGDS)
 	defer close(msgChannel)

--- a/collectors/forwarder/collector/syslog/handler.go
+++ b/collectors/forwarder/collector/syslog/handler.go
@@ -68,7 +68,9 @@ func (inst *syslogInstance) readLoop(ctx context.Context, reader *bufio.Reader, 
 	}
 }
 
-func (inst *syslogInstance) handleConnectionTCP(c net.Conn, queue chan *plugins.Log) {
+// ctx is a parameter on purpose: reading ctx here needs the
+// mutex and can latch onto the context of a listener installed by a later enable.
+func (inst *syslogInstance) handleConnectionTCP(ctx context.Context, c net.Conn, queue chan *plugins.Log) {
 	defer c.Close()
 	reader := bufio.NewReader(c)
 	remoteAddr := resolveRemoteAddr(c.RemoteAddr().String())
@@ -94,12 +96,12 @@ func (inst *syslogInstance) handleConnectionTCP(c net.Conn, queue chan *plugins.
 
 	msgChannel := make(chan MSGDS)
 	defer close(msgChannel)
-	go inst.handleMessage(inst.TCPListener.CTX, msgChannel, queue)
+	go inst.handleMessage(ctx, msgChannel, queue)
 
-	inst.readLoop(inst.TCPListener.CTX, reader, remoteAddr, msgChannel, nil)
+	inst.readLoop(ctx, reader, remoteAddr, msgChannel, nil)
 }
 
-func (inst *syslogInstance) handleTLSConnection(conn net.Conn, queue chan *plugins.Log) {
+func (inst *syslogInstance) handleTLSConnection(ctx context.Context, conn net.Conn, queue chan *plugins.Log) {
 	defer conn.Close()
 
 	remoteAddr := resolveRemoteAddr(conn.RemoteAddr().String())
@@ -124,9 +126,9 @@ func (inst *syslogInstance) handleTLSConnection(conn net.Conn, queue chan *plugi
 	reader := bufio.NewReader(tlsConn)
 	msgChannel := make(chan MSGDS)
 	defer close(msgChannel)
-	go inst.handleMessage(inst.TCPListener.CTX, msgChannel, queue)
+	go inst.handleMessage(ctx, msgChannel, queue)
 
-	inst.readLoop(inst.TCPListener.CTX, reader, remoteAddr, msgChannel, conn)
+	inst.readLoop(ctx, reader, remoteAddr, msgChannel, conn)
 }
 
 // handleMessage processes messages from the channel and sends them to the queue.

--- a/collectors/forwarder/collector/syslog/handler.go
+++ b/collectors/forwarder/collector/syslog/handler.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"crypto/tls"
+	"errors"
 	"io"
 	"net"
 	"os"
@@ -49,17 +50,26 @@ func (inst *syslogInstance) readLoop(ctx context.Context, reader *bufio.Reader, 
 			}
 			message, err := readSyslogMessage(reader)
 			if err != nil {
-				if err == io.EOF {
+				if ctx.Err() != nil {
+					utils.Logger.Info("%s connection from %s released on shutdown", connType, remoteAddr)
+					return
+				}
+
+				if errors.Is(err, io.EOF) {
 					utils.Logger.Info("%s connection closed by %s", connType, remoteAddr)
 					return
 				}
-				if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+
+				var netErr net.Error
+				if errors.As(err, &netErr) && netErr.Timeout() {
 					utils.Logger.Info("%s connection timeout from %s", connType, remoteAddr)
 					return
 				}
+
 				utils.Logger.ErrorF("error reading %s data from %s: %v", connType, remoteAddr, err)
 				return
 			}
+
 			// msgChannel is unbuffered and handleMessage returns on ctx.Done,
 			// so an unguarded send parks here forever and leaks the connection.
 			select {
@@ -74,7 +84,7 @@ func (inst *syslogInstance) readLoop(ctx context.Context, reader *bufio.Reader, 
 	}
 }
 
-// ctx is a parameter on purpose: reading ctx here needs the
+// ctx is a parameter on purpose: reading inst.TCPListener.CTX here needs the
 // mutex and can latch onto the context of a listener installed by a later enable.
 func (inst *syslogInstance) handleConnectionTCP(ctx context.Context, c net.Conn, queue chan *plugins.Log) {
 	defer c.Close()
@@ -147,7 +157,6 @@ func (inst *syslogInstance) handleTLSConnection(ctx context.Context, conn net.Co
 	inst.readLoop(ctx, reader, remoteAddr, msgChannel, conn)
 }
 
-// handleMessage processes messages from the channel and sends them to the queue.
 func (inst *syslogInstance) handleMessage(ctx context.Context, logsChannel chan MSGDS, queue chan *plugins.Log) {
 	for {
 		select {

--- a/collectors/forwarder/collector/syslog/listener.go
+++ b/collectors/forwarder/collector/syslog/listener.go
@@ -135,32 +135,37 @@ func (inst *syslogInstance) enableTCP(queue chan *plugins.Log) {
 		return
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
+	port := inst.TCPListener.Port
+	tlsEnabled := inst.TCPListener.TLSEnabled
+
 	inst.TCPListener.IsEnabled = true
 	inst.TCPListener.Listener = listener
-	inst.TCPListener.CTX, inst.TCPListener.Cancel = context.WithCancel(context.Background())
+	inst.TCPListener.CTX, inst.TCPListener.Cancel = ctx, cancel
 	inst.mu.Unlock()
 
-	utils.Logger.Info("Server %s listening in port: %s protocol: TCP", inst.DataType, inst.TCPListener.Port)
-	if inst.TCPListener.TLSEnabled {
-		utils.Logger.Info("Server %s TLS enabled in port: %s protocol: TCP", inst.DataType, inst.TCPListener.Port)
+	utils.Logger.Info("Server %s listening in port: %s protocol: TCP", inst.DataType, port)
+	if tlsEnabled {
+		utils.Logger.Info("Server %s TLS enabled in port: %s protocol: TCP", inst.DataType, port)
 	}
 
+	// enableTCP/disableTCP own the listener; closing it here closes it twice.
+	// The panic path is the exception: nobody is accepting any more, so the
+	// socket must go down too. Leaving it open would keep accepting peers whose
+	// logs are never read, which loses data silently instead of failing loudly.
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
 				utils.Logger.ErrorF("panic in TCP listener for %s: %v", inst.DataType, r)
-			}
-			err = inst.TCPListener.Listener.Close()
-			if err != nil {
-				utils.Logger.ErrorF("error closing tcp listener: %v", err)
+				inst.disableTCP()
 			}
 		}()
 		for {
 			select {
-			case <-inst.TCPListener.CTX.Done():
+			case <-ctx.Done():
 				return
 			default:
-				conn, err := inst.TCPListener.Listener.Accept()
+				conn, err := listener.Accept()
 				if err != nil {
 					if errors.Is(err, net.ErrClosed) {
 						return
@@ -176,10 +181,10 @@ func (inst *syslogInstance) enableTCP(queue chan *plugins.Log) {
 					continue
 				}
 
-				if inst.TCPListener.TLSEnabled {
-					go inst.handleTLSConnection(conn, queue)
+				if tlsEnabled {
+					go inst.handleTLSConnection(ctx, conn, queue)
 				} else {
-					go inst.handleConnectionTCP(conn, queue)
+					go inst.handleConnectionTCP(ctx, conn, queue)
 				}
 			}
 		}
@@ -208,31 +213,34 @@ func (inst *syslogInstance) enableUDP(queue chan *plugins.Log) {
 		return
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
+	port := inst.UDPListener.Port
+
 	inst.UDPListener.IsEnabled = true
 	inst.UDPListener.Listener = listener
-	inst.UDPListener.CTX, inst.UDPListener.Cancel = context.WithCancel(context.Background())
+	inst.UDPListener.CTX, inst.UDPListener.Cancel = ctx, cancel
 	inst.mu.Unlock()
 
-	utils.Logger.Info("Server %s listening in port: %s protocol: UDP", inst.DataType, inst.UDPListener.Port)
+	utils.Logger.Info("Server %s listening in port: %s protocol: UDP", inst.DataType, port)
 
 	buffer := make([]byte, UDPBufferSize)
 	msgChannel := make(chan MSGDS)
 
-	go inst.handleMessage(inst.UDPListener.CTX, msgChannel, queue)
+	go inst.handleMessage(ctx, msgChannel, queue)
 
+	// enableUDP/disableUDP own the listener; closing it here closes it twice.
+	// The panic path is the exception: see enableTCP.
 	go func() {
 		defer close(msgChannel)
 		defer func() {
 			if r := recover(); r != nil {
 				utils.Logger.ErrorF("panic in UDP listener for %s: %v", inst.DataType, r)
-			}
-			if err := inst.UDPListener.Listener.Close(); err != nil {
-				utils.Logger.ErrorF("error closing udp listener: %v", err)
+				inst.disableUDP()
 			}
 		}()
 		for {
 			select {
-			case <-inst.UDPListener.CTX.Done():
+			case <-ctx.Done():
 				return
 			default:
 				udpListener.SetDeadline(time.Now().Add(time.Second * 1))


### PR DESCRIPTION
Started from one bogus error on disable and ended up fixing the pattern behind it.

### What it fixes

| Before | Now |
|---|---|
| Disable logged `error closing tcp listener: use of closed network connection` | Clean close, no error |
| Every client disconnect logged 2× ERROR | 1× INFO |
| Config changes on an enabled HTTP integration were silently ignored | Applied without disabling first |
| A typo in an integration path killed the whole HTTP collector | That integration is skipped, the rest keep running |
| Disable with traffic leaked a goroutine + fd per connection | Connections released |
| Stop could leave ports bound → `address already in use` | All ports released, immediate restart works |
| Listener/context fields read without the mutex (syslog, netflow, file) | Captured as locals under the lock |

### Root cause

A long-running goroutine read shared struct fields without the mutex the reconcile
path writes under, and no one owned the socket. Same mistake in four files.

### Validation

Built and installed against a live backend. TCP, UDP and HTTP: enable, send logs,
disable. Logs arrived, ports released, immediate restart clean. 