### PR TITLE
feat(plugins): distribute ingestion ownership across event-processor workers

### DIFF
--- a/plugins/aws/client.go
+++ b/plugins/aws/client.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"sync"
+
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+
+	"github.com/utmstack/UTMStack/plugins/shared/identity"
+)
+
+// clientCache hands out one client per (region, credentials). CloudWatch
+// Logs throttling quotas are enforced per account and region and shared by
+// every group using them, so client scope must match the quota, not the group.
+type clientCache struct {
+	mu      sync.Mutex
+	clients map[string]*cloudwatchlogs.Client
+}
+
+func newClientCache() *clientCache {
+	return &clientCache{clients: make(map[string]*cloudwatchlogs.Client)}
+}
+
+// Credentials are hashed because this key reaches log lines and error
+// contexts, where a secret access key must never appear.
+func clientCacheKey(region, accessKey, secretAccessKey string) string {
+	return region + "|" + identity.Hash(accessKey, secretAccessKey)
+}
+
+// The lock is intentionally not held across construction: it blocks on I/O
+// for up to a minute, so holding it would let one bad credential set stall
+// every other group's lookup. The re-check below discards a racing duplicate.
+func (c *clientCache) get(region, accessKey, secretAccessKey string) (*cloudwatchlogs.Client, error) {
+	key := clientCacheKey(region, accessKey, secretAccessKey)
+
+	c.mu.Lock()
+	cached, ok := c.clients[key]
+	c.mu.Unlock()
+	if ok {
+		return cached, nil
+	}
+
+	client, err := newCloudWatchLogsClient(region, accessKey, secretAccessKey)
+	if err != nil {
+		return nil, err
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if winner, ok := c.clients[key]; ok {
+		return winner, nil
+	}
+	c.clients[key] = client
+	return client, nil
+}
+
+var awsClients = newClientCache()
+
+func newCloudWatchLogsClient(region, accessKey, secretAccessKey string) (*cloudwatchlogs.Client, error) {
+	processor := AWSProcessor{
+		RegionName:      region,
+		AccessKey:       accessKey,
+		SecretAccessKey: secretAccessKey,
+	}
+
+	cfg, err := processor.createAWSSession()
+	if err != nil {
+		return nil, err
+	}
+
+	return cloudwatchlogs.NewFromConfig(cfg), nil
+}
+
+func (p *AWSProcessor) client() (*cloudwatchlogs.Client, error) {
+	return awsClients.get(p.RegionName, p.AccessKey, p.SecretAccessKey)
+}

--- a/plugins/aws/config.go
+++ b/plugins/aws/config.go
@@ -1,10 +1,6 @@
 package main
 
 import (
-	"crypto/aes"
-	"crypto/cipher"
-	"crypto/sha1"
-	"encoding/base64"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -14,13 +10,14 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/threatwinds/go-sdk/catcher"
 	"github.com/threatwinds/go-sdk/plugins"
-	"golang.org/x/crypto/pbkdf2"
+	"github.com/utmstack/UTMStack/plugins/shared/crypto"
 	"gopkg.in/yaml.v3"
 )
 
 const (
 	pluginFile         = "system_plugins_aws.yaml"
-	processName        = "plugin_com.utmstack.aws"
+	pluginName         = "com.utmstack.aws"
+	processName        = "plugin_" + pluginName
 	pipelineDirDefault = "/workdir/pipeline"
 )
 
@@ -84,7 +81,6 @@ func StartConfigurationSystem() {
 
 	filePath := filepath.Join(pipelineDir, pluginFile)
 
-	// Initial load.
 	if sec := readConfig(filePath, encKey); sec != nil {
 		mu.Lock()
 		cnf = sec
@@ -100,7 +96,7 @@ func StartConfigurationSystem() {
 	}
 	defer watcher.Close()
 
-	// Watch the directory so we catch atomic write (rename) events.
+	// The directory, not the file: atomic writes arrive as renames.
 	if err := watcher.Add(pipelineDir); err != nil {
 		_ = catcher.Error("failed to watch pipeline dir", err, map[string]any{"process": processName})
 		pollFallback(filePath, encKey)
@@ -182,8 +178,7 @@ func readConfig(path, encKey string) *ConfigurationSection {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			// File removed → module disabled / no configuration. Report an empty,
-			// inactive section so the module is treated as disabled and all work stops.
+			// A removed file means the module is disabled, not an error.
 			return &ConfigurationSection{ModuleActive: false}
 		}
 		_ = catcher.Error("failed to read config file", err, map[string]any{"process": processName, "file": path})
@@ -210,7 +205,7 @@ func readConfig(path, encKey string) *ConfigurationSection {
 			for k, v := range g.Config {
 				conf := &Configuration{ConfKey: k, ConfValue: v}
 				if encKey != "" && sensitiveKeys[k] {
-					dec, err := NewCipher(encKey).Decrypt(conf.ConfValue)
+					dec, err := crypto.NewCipher(encKey).Decrypt(conf.ConfValue)
 					if err == nil {
 						conf.ConfValue = dec
 					}
@@ -220,64 +215,6 @@ func readConfig(path, encKey string) *ConfigurationSection {
 			sec.ModuleGroups = append(sec.ModuleGroups, grp)
 		}
 	}
-	// A tenant section with no groups must not read as configured.
 	sec.ModuleActive = len(sec.ModuleGroups) > 0
 	return sec
-}
-
-const (
-	iterationCount = 65536
-	keyLength      = 16
-)
-
-type Cipher struct {
-	key []byte
-}
-
-func NewCipher(key string) *Cipher {
-	return &Cipher{key: []byte(key)}
-}
-
-func (c *Cipher) setKey() (cipher.Block, []byte, error) {
-	h := sha1.New()
-	h.Write(c.key)
-	salt := h.Sum(nil)
-	keyEnc := pbkdf2.Key(c.key, salt, iterationCount, keyLength, sha1.New)
-	block, err := aes.NewCipher(keyEnc)
-	if err != nil {
-		return nil, nil, err
-	}
-	return block, salt[:keyLength], nil
-}
-
-func (c *Cipher) Decrypt(crypt string) (string, error) {
-	if crypt == "" {
-		return "", nil
-	}
-	encryptedData, err := base64.StdEncoding.DecodeString(crypt)
-	if err != nil {
-		return crypt, nil // not base64 → already plaintext
-	}
-	blk, iv, err := c.setKey()
-	if err != nil {
-		return crypt, err
-	}
-	if len(encryptedData)%aes.BlockSize != 0 {
-		return crypt, nil // not a valid CBC block → already plaintext
-	}
-	dec := cipher.NewCBCDecrypter(blk, iv)
-	decrypted := make([]byte, len(encryptedData))
-	dec.CryptBlocks(decrypted, encryptedData)
-	return string(pkcs5Trim(decrypted)), nil
-}
-
-func pkcs5Trim(data []byte) []byte {
-	if len(data) == 0 {
-		return data
-	}
-	padding := int(data[len(data)-1])
-	if padding > len(data) || padding == 0 {
-		return data
-	}
-	return data[:len(data)-padding]
 }

--- a/plugins/aws/connectivity.go
+++ b/plugins/aws/connectivity.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	"github.com/threatwinds/go-sdk/catcher"
+)
+
+const connectivityRetryDelay = 5 * time.Second
+
+func waitForConnectivity(ctx context.Context, checker func(string) error, url string, retryDelay time.Duration) {
+	for {
+		if err := checker(url); err != nil {
+			_ = catcher.Error("failed to connect with external service", err, map[string]any{"process": processName})
+			if !sleepWithCancel(ctx, retryDelay) {
+				return
+			}
+			continue
+		}
+		return
+	}
+}

--- a/plugins/aws/cursor.go
+++ b/plugins/aws/cursor.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"encoding/json"
+	"sync"
+)
+
+// One goroutine polls per log stream, so a group's position is the merge of
+// every stream's independently advancing NextForwardToken.
+type cursorMap struct {
+	mu      sync.Mutex
+	entries map[string]*string
+}
+
+func newCursorMap() *cursorMap {
+	return &cursorMap{entries: make(map[string]*string)}
+}
+
+// Only the stream's own goroutine may call this; a second writer for the
+// same key breaks delete's invariant.
+func (c *cursorMap) set(stream string, token *string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[stream] = token
+}
+
+func (c *cursorMap) get(stream string) (*string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	v, ok := c.entries[stream]
+	return v, ok
+}
+
+// Callers must guarantee no set for this key can land afterwards, or the
+// entry is resurrected: cancel the stream's goroutine first, or call this
+// from that goroutine as it returns. To drop a live stream's token, use
+// set(stream, nil) instead.
+func (c *cursorMap) delete(stream string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.entries, stream)
+}
+
+func (c *cursorMap) snapshot() map[string]*string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make(map[string]*string, len(c.entries))
+	for k, v := range c.entries {
+		out[k] = v
+	}
+	return out
+}
+
+func (c *cursorMap) marshalSnapshot() ([]byte, error) {
+	return json.Marshal(c.snapshot())
+}
+
+// Only safe before the group's stream goroutines start.
+func (c *cursorMap) replace(entries map[string]*string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if entries == nil {
+		entries = make(map[string]*string)
+	}
+	c.entries = entries
+}
+
+// A returned token makes GetLogEvents ignore StartTime. On nil the caller
+// must fall back to the group's baseline start time, not "now": streams are
+// only discovered every 5 minutes, so "now" silently drops everything a
+// late-discovered stream received before that.
+func seedNextToken(cursors *cursorMap, stream string) *string {
+	if token, ok := cursors.get(stream); ok {
+		return token
+	}
+	return nil
+}

--- a/plugins/aws/go.mod
+++ b/plugins/aws/go.mod
@@ -9,7 +9,10 @@ require (
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/google/uuid v1.6.0
 	github.com/threatwinds/go-sdk v1.1.28
+	github.com/utmstack/UTMStack/plugins/shared v0.0.0-00010101000000-000000000000
 )
+
+replace github.com/utmstack/UTMStack/plugins/shared => ../shared
 
 require (
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.38 // indirect
@@ -17,6 +20,10 @@ require (
 	github.com/bytedance/gopkg v0.1.4 // indirect
 	github.com/goccy/go-yaml v1.19.2 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
+	github.com/klauspost/compress v1.18.5 // indirect
+	github.com/nats-io/nats.go v1.53.1 // indirect
+	github.com/nats-io/nkeys v0.4.15 // indirect
+	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/opensearch-project/opensearch-go/v4 v4.6.0 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/quic-go/quic-go v0.59.1 // indirect
@@ -63,7 +70,7 @@ require (
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.1 // indirect
 	golang.org/x/arch v0.27.0 // indirect
-	golang.org/x/crypto v0.55.0
+	golang.org/x/crypto v0.55.0 // indirect
 	golang.org/x/exp v0.0.0-20260603202125-055de637280b // indirect
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect

--- a/plugins/aws/go.sum
+++ b/plugins/aws/go.sum
@@ -85,6 +85,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBFW2IE=
+github.com/klauspost/compress v1.18.5/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
 github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -100,6 +102,12 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/nats-io/nats.go v1.53.1 h1:Otsq3uLc/kLdjmkNHkXH0jBqwUquwdKFoe3fq6/3/Xo=
+github.com/nats-io/nats.go v1.53.1/go.mod h1:26HypzazeOkyO3/mqd1zZd53STJN0EjCYF9Uy2ZOBno=
+github.com/nats-io/nkeys v0.4.15 h1:JACV5jRVO9V856KOapQ7x+EY8Jo3qw1vJt/9Jpwzkk4=
+github.com/nats-io/nkeys v0.4.15/go.mod h1:CpMchTXC9fxA5zrMo4KpySxNjiDVvr8ANOSZdiNfUrs=
+github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=
+github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/opensearch-project/opensearch-go/v4 v4.6.0 h1:Ac8aLtDSmLEyOmv0r1qhQLw3b4vcUhE42NE9k+Z4cRc=
 github.com/opensearch-project/opensearch-go/v4 v4.6.0/go.mod h1:3iZtb4SNt3IzaxavKq0dURh1AmtVgYW71E4XqmYnIiQ=
 github.com/pelletier/go-toml/v2 v2.3.1 h1:MYEvvGnQjeNkRF1qUuGolNtNExTDwct51yp7olPtrEc=

--- a/plugins/aws/heartbeat.go
+++ b/plugins/aws/heartbeat.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"errors"
+
+	"github.com/threatwinds/go-sdk/catcher"
+	"github.com/utmstack/UTMStack/plugins/shared/coordination"
+)
+
+// cancel must be this group's own CancelFunc: fencing uses it to stop the
+// group, so a wider one would take down unrelated groups. Nil is allowed
+// only when the caller drives Tick itself.
+func groupHeartbeat(coord coordination.LeasePath, cursorKey string, cursors *cursorMap, cancel context.CancelFunc) coordination.Heartbeat {
+	return coordination.Heartbeat{
+		Leases:   coord.Leases,
+		Cursors:  coord.Cursors,
+		Key:      cursorKey,
+		Snapshot: cursors.marshalSnapshot,
+		TTL:      coordination.LeaseTTL,
+		Interval: coordination.HeartbeatInterval,
+		Cancel:   cancel,
+		OnError:  reportHeartbeatFailure(cursorKey),
+	}
+}
+
+func reportHeartbeatFailure(cursorKey string) func(error) {
+	return func(err error) {
+		switch {
+		case errors.Is(err, coordination.ErrFenced):
+			catcher.Info("lease fenced, stopping group", map[string]any{
+				"process": processName,
+				"key":     cursorKey,
+			})
+
+		case errors.Is(err, coordination.ErrCursorTooLarge):
+			_ = catcher.Error("cursor snapshot exceeds the maximum persistable size, will NOT resolve by retrying — this group's stream count is too large for a single cursor entry", err, map[string]any{
+				"process": processName,
+				"key":     cursorKey,
+			})
+
+		default:
+			_ = catcher.Error("failed to persist cursor snapshot, will retry next heartbeat", err, map[string]any{
+				"process": processName,
+				"key":     cursorKey,
+			})
+		}
+	}
+}

--- a/plugins/aws/identity.go
+++ b/plugins/aws/identity.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"strconv"
+
+	"github.com/utmstack/UTMStack/plugins/shared/identity"
+)
+
+// CloudWatch carries no per-event ID, so the whole message must be hashed.
+// groupKey must be ModuleGroup.Key(): log group and stream names are
+// administrator-typed, so two tenants in separate AWS accounts can pick
+// identical ones, and without it identical content collides across tenants.
+func eventIdentity(groupKey, logGroup, streamName string, timestamp int64, message string) string {
+	return identity.Hash(groupKey, logGroup, streamName, strconv.FormatInt(timestamp, 10), message)
+}

--- a/plugins/aws/main.go
+++ b/plugins/aws/main.go
@@ -10,36 +10,47 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	awsConfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 
 	"github.com/google/uuid"
 	"github.com/threatwinds/go-sdk/catcher"
 	"github.com/threatwinds/go-sdk/plugins"
+	"github.com/utmstack/UTMStack/plugins/shared/coordination"
 )
 
-// defaultTenant is the fallback used only when a connector instance's config
-// has no tenantId (every on-prem/single-tenant install today).
 const (
 	defaultTenant      = "ce66672c-e36d-4761-a8c8-90058fee1a24"
 	urlCheckConnection = "https://sts.amazonaws.com"
 	wait               = 1 * time.Second
 )
 
+// One goroutine polls per log stream, so idle request volume scales with
+// stream count, not log volume. idlePollMax stays well under the 5-minute
+// discovery interval in streamLogs so it never dominates ingestion lag.
+const (
+	idlePollBase = 5 * time.Second
+	idlePollMax  = 60 * time.Second
+)
+
 type activeGroupStream struct {
-	cancel context.CancelFunc
-	config AWSProcessor
+	cancel  context.CancelFunc
+	config  AWSProcessor
+	cursors *cursorMap
 }
 
 var (
 	activeStreams = make(map[string]*activeGroupStream)
 )
 
+// coordinationRetryDelay paces retries while coordination is unreachable.
+const coordinationRetryDelay = 5 * time.Second
+
 func main() {
-	mode := plugins.GetCfg("plugin_com.utmstack.aws").Env.Mode
-	if mode != "manager" {
+	mode := plugins.GetCfg(processName).Env.Mode
+	if mode != "worker" {
 		return
 	}
 
@@ -47,27 +58,39 @@ func main() {
 
 	for t := 0; t < 2*runtime.NumCPU(); t++ {
 		go func() {
-			plugins.SendLogsFromChannel("com.utmstack.aws")
+			plugins.SendLogsFromChannel(pluginName)
 		}()
 	}
 
-	for {
-		if err := connectionChecker(urlCheckConnection); err != nil {
-			_ = catcher.Error("failed to connect with external service", err, map[string]any{"process": "plugin_com.utmstack.aws"})
-			continue
-		}
-		break
-	}
+	ctx := context.Background()
 
-	watchConfigChanges()
+	waitForConnectivity(ctx, connectionChecker, urlCheckConnection, connectivityRetryDelay)
+
+	// Blocks until coordination succeeds; there is no uncoordinated fallback,
+	// because without a lease two workers can claim the same group.
+	setup, err := coordination.SetupWithRetry(ctx, coordination.DialLeasePath(processName), coordinationRetryDelay, func(err error) {
+		_ = catcher.Error("coordination setup failed, waiting to retry", err, map[string]any{
+			"process": processName,
+		})
+	})
+	if err != nil {
+		// Only reachable if ctx is cancelled.
+		_ = catcher.Error("coordination setup cancelled before it could succeed", err, map[string]any{"process": processName})
+		return
+	}
+	defer setup.Close()
+
+	holder := uuid.NewString()
+
+	watchConfigChanges(ctx, setup, holder)
 }
 
-func watchConfigChanges() {
+func watchConfigChanges(ctx context.Context, coord coordination.LeasePath, holder string) {
 	time.Sleep(3 * time.Second)
 
 	initialConfig := GetConfig()
 	if initialConfig != nil && initialConfig.ModuleActive {
-		syncStreams(initialConfig)
+		syncStreams(ctx, coord, holder, initialConfig)
 	}
 
 	for newConfig := range GetConfigUpdateChannel() {
@@ -76,11 +99,11 @@ func watchConfigChanges() {
 			continue
 		}
 
-		syncStreams(newConfig)
+		syncStreams(ctx, coord, holder, newConfig)
 	}
 }
 
-func syncStreams(moduleConfig *ConfigurationSection) {
+func syncStreams(ctx context.Context, coord coordination.LeasePath, holder string, moduleConfig *ConfigurationSection) {
 	currentKeys := make(map[string]bool)
 	for _, group := range moduleConfig.ModuleGroups {
 		currentConfig := getAWSProcessor(group)
@@ -90,15 +113,15 @@ func syncStreams(moduleConfig *ConfigurationSection) {
 		existing := activeStreams[groupKey]
 
 		if existing == nil {
-			startGroupStream(groupKey, group)
+			startGroupStream(ctx, coord, holder, groupKey, group)
 		} else if existing.config != currentConfig {
 			catcher.Info("Configuration changed for group, restarting", map[string]any{
 				"group":   group.GroupName,
-				"process": "plugin_com.utmstack.aws",
+				"process": processName,
 			})
 			existing.cancel()
 			delete(activeStreams, groupKey)
-			startGroupStream(groupKey, group)
+			startGroupStream(ctx, coord, holder, groupKey, group)
 		}
 	}
 
@@ -106,7 +129,7 @@ func syncStreams(moduleConfig *ConfigurationSection) {
 		if !currentKeys[groupKey] {
 			catcher.Info("Group removed, stopping stream", map[string]any{
 				"group":   groupKey,
-				"process": "plugin_com.utmstack.aws",
+				"process": processName,
 			})
 			stream.cancel()
 			delete(activeStreams, groupKey)
@@ -114,22 +137,71 @@ func syncStreams(moduleConfig *ConfigurationSection) {
 	}
 }
 
-func startGroupStream(groupKey string, group *ModuleGroup) {
-	ctx, cancel := context.WithCancel(context.Background())
+func startGroupStream(ctx context.Context, coord coordination.LeasePath, holder, groupKey string, group *ModuleGroup) {
+	groupCtx, cancel := context.WithCancel(ctx)
 
 	groupConfig := getAWSProcessor(group)
+	cursors := newCursorMap()
 
 	activeStreams[groupKey] = &activeGroupStream{
-		cancel: cancel,
-		config: groupConfig,
+		cancel:  cancel,
+		config:  groupConfig,
+		cursors: cursors,
 	}
 
 	catcher.Info("Starting stream for group", map[string]any{
 		"group":   group.GroupName,
-		"process": "plugin_com.utmstack.aws",
+		"process": processName,
 	})
 
-	go streamLogs(ctx, group)
+	go acquireLeaseAndStream(groupCtx, coord, holder, groupKey, cursors, cancel, func() {
+		streamLogs(groupCtx, group, groupKey, cursors)
+	})
+}
+
+// Must be called in the group's own goroutine: this blocks until the lease
+// is owned, so a contended lease would stall syncStreams for every group.
+func acquireLeaseAndStream(ctx context.Context, coord coordination.LeasePath, holder, groupKey string, cursors *cursorMap, cancel context.CancelFunc, run func()) {
+	leaseKey := "aws." + groupKey
+
+	lease, err := coordination.AcquireWithRetry(
+		ctx, coord.Leases, leaseKey, holder,
+		coordination.LeaseTTL, coordination.AcquireRetryInterval,
+		func(err error) {
+			_ = catcher.Error("failed to acquire group lease", err, map[string]any{
+				"process": processName,
+				"group":   groupKey,
+			})
+		},
+	)
+	if err != nil {
+		return
+	}
+
+	cursorRev := loadGroupCursor(ctx, coord.Cursors, leaseKey, groupKey, cursors)
+
+	go groupHeartbeat(coord, leaseKey, cursors, cancel).Run(ctx, lease, cursorRev)
+
+	run()
+}
+
+func loadGroupCursor(ctx context.Context, cursors coordination.CursorStore, leaseKey, groupKey string, dst *cursorMap) uint64 {
+	var entries map[string]*string
+
+	rev, found, err := coordination.LoadCursorInto(ctx, cursors, leaseKey, &entries)
+	if err != nil {
+		_ = catcher.Error("failed to load persisted cursor snapshot", err, map[string]any{
+			"process": processName,
+			"group":   groupKey,
+		})
+	}
+	if found {
+		dst.replace(entries)
+	}
+
+	// Returned even when the decode failed: the next Save needs this
+	// revision to be a valid CAS update rather than a doomed create.
+	return rev
 }
 
 func stopAllStreams() {
@@ -139,7 +211,7 @@ func stopAllStreams() {
 
 	catcher.Info("Stopping all active streams", map[string]any{
 		"count":   len(activeStreams),
-		"process": "plugin_com.utmstack.aws",
+		"process": processName,
 	})
 
 	for groupKey, stream := range activeStreams {
@@ -157,16 +229,14 @@ func sleepWithCancel(ctx context.Context, d time.Duration) bool {
 	}
 }
 
-func streamLogs(ctx context.Context, group *ModuleGroup) {
+func streamLogs(ctx context.Context, group *ModuleGroup, groupKey string, cursors *cursorMap) {
 	agent := getAWSProcessor(group)
 
-	awsConfig, err := agent.createAWSSession()
+	cwl, err := agent.client()
 	if err != nil {
-		_ = catcher.Error("cannot create AWS session", err, map[string]any{"process": "plugin_com.utmstack.aws"})
+		_ = catcher.Error("cannot create AWS session", err, map[string]any{"process": processName})
 		return
 	}
-
-	cwl := cloudwatchlogs.NewFromConfig(awsConfig)
 
 	startTime := time.Now().UTC()
 
@@ -174,7 +244,7 @@ func streamLogs(ctx context.Context, group *ModuleGroup) {
 		"group":     group.GroupName,
 		"logGroup":  agent.LogGroup,
 		"startTime": startTime.Format(time.RFC3339),
-		"process":   "plugin_com.utmstack.aws",
+		"process":   processName,
 	})
 
 	currentStreams := make(map[string]context.CancelFunc)
@@ -189,7 +259,7 @@ func streamLogs(ctx context.Context, group *ModuleGroup) {
 		if err != nil {
 			_ = catcher.Error("cannot get log streams", err, map[string]any{
 				"logGroup": agent.LogGroup,
-				"process":  "plugin_com.utmstack.aws",
+				"process":  processName,
 			})
 			if !sleepWithCancel(ctx, 30*time.Second) {
 				return
@@ -205,7 +275,7 @@ func streamLogs(ctx context.Context, group *ModuleGroup) {
 			streamCtx, streamCancel := context.WithCancel(ctx)
 			currentStreams[stream] = streamCancel
 
-			go streamLogStream(streamCtx, cwl, agent.LogGroup, stream, startTime, group.GroupName, agent.TenantId)
+			go streamLogStream(streamCtx, cwl, agent.LogGroup, stream, startTime, group.GroupName, agent.TenantId, groupKey, cursors)
 		}
 
 		awsStreamsMap := make(map[string]bool)
@@ -218,17 +288,20 @@ func streamLogs(ctx context.Context, group *ModuleGroup) {
 				catcher.Info("Log stream expired, stopping", map[string]any{
 					"logGroup":  agent.LogGroup,
 					"logStream": streamName,
-					"process":   "plugin_com.utmstack.aws",
+					"process":   processName,
 				})
 				cancel()
+				// Prune only after cancel, so no in-flight cursors.set can
+				// land after the delete and resurrect the entry.
 				delete(currentStreams, streamName)
+				cursors.delete(streamName)
 			}
 		}
 
 		if !sleepWithCancel(ctx, 5*time.Minute) {
 			catcher.Info("Stream cancelled for group", map[string]any{
 				"group":   group.GroupName,
-				"process": "plugin_com.utmstack.aws",
+				"process": processName,
 			})
 			return
 		}
@@ -263,30 +336,18 @@ func getAWSProcessor(group *ModuleGroup) AWSProcessor {
 func (p *AWSProcessor) createAWSSession() (aws.Config, error) {
 	if p.RegionName == "" {
 		return aws.Config{}, catcher.Error("cannot create AWS session",
-			errors.New("region name is empty"), map[string]any{"process": "plugin_com.utmstack.aws"})
+			errors.New("region name is empty"), map[string]any{"process": processName})
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
 
-	adaptiveRetryer := retry.NewAdaptiveMode(func(ao *retry.AdaptiveModeOptions) {
-		ao.StandardOptions = append(ao.StandardOptions, func(so *retry.StandardOptions) {
-			so.MaxAttempts = 10              // Increment max attempts for throttling
-			so.MaxBackoff = 30 * time.Second // Increase max backoff time
-		})
-		ao.RequestCost = 1
-		ao.FailOnNoAttemptTokens = false // Allow retries even without tokens
-	})
-
 	cfg, err := awsConfig.LoadDefaultConfig(ctx,
 		awsConfig.WithRegion(p.RegionName),
 		awsConfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(p.AccessKey, p.SecretAccessKey, "")),
-		awsConfig.WithRetryer(func() aws.Retryer {
-			return adaptiveRetryer
-		}),
 	)
 	if err != nil {
-		return aws.Config{}, catcher.Error("cannot create AWS session", err, map[string]any{"process": "plugin_com.utmstack.aws"})
+		return aws.Config{}, catcher.Error("cannot create AWS session", err, map[string]any{"process": processName})
 	}
 
 	return cfg, nil
@@ -306,7 +367,7 @@ func describeLogStreams(ctx context.Context, cwl *cloudwatchlogs.Client, logGrou
 		page, err := paginator.NextPage(requestCtx)
 		if err != nil {
 			cancel()
-			return nil, catcher.Error("cannot get log streams", err, map[string]any{"process": "plugin_com.utmstack.aws"})
+			return nil, catcher.Error("cannot get log streams", err, map[string]any{"process": processName})
 		}
 		for _, stream := range page.LogStreams {
 			logStreams = append(logStreams, *stream.LogStreamName)
@@ -318,12 +379,17 @@ func describeLogStreams(ctx context.Context, cwl *cloudwatchlogs.Client, logGrou
 	return logStreams, nil
 }
 
-func streamLogStream(ctx context.Context, cwl *cloudwatchlogs.Client, logGroup, streamName string, startTime time.Time, dataSource, tenantId string) {
+type logEventsAPI interface {
+	GetLogEvents(ctx context.Context, params *cloudwatchlogs.GetLogEventsInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.GetLogEventsOutput, error)
+}
+
+func streamLogStream(ctx context.Context, cwl logEventsAPI, logGroup, streamName string, startTime time.Time, dataSource, tenantId, groupKey string, cursors *cursorMap) {
 	if tenantId == "" {
 		tenantId = defaultTenant
 	}
-	var nextToken *string
+	nextToken := seedNextToken(cursors, streamName)
 	processedCount := 0
+	idleWait := idlePollBase
 
 	for {
 		select {
@@ -331,19 +397,24 @@ func streamLogStream(ctx context.Context, cwl *cloudwatchlogs.Client, logGroup, 
 			catcher.Info("Log stream cancelled", map[string]any{
 				"stream":     streamName,
 				"totalCount": processedCount,
-				"process":    "plugin_com.utmstack.aws",
+				"process":    processName,
 			})
 			return
 		default:
 		}
+
+		// At end of stream CloudWatch returns the same token it was sent.
+		// That equality is the only end-of-stream signal it gives.
+		sentToken := nextToken
 
 		input := &cloudwatchlogs.GetLogEventsInput{
 			LogGroupName:  aws.String(logGroup),
 			LogStreamName: aws.String(streamName),
 			StartTime:     aws.Int64(startTime.Unix() * 1000),
 			StartFromHead: aws.Bool(true),
-			NextToken:     nextToken,
-			Limit:         aws.Int32(1000),
+			NextToken:     sentToken,
+			// Left unset so the API default applies: 1 MB per response, up
+			// to 10,000 events. An event count would not bound bytes.
 		}
 
 		requestCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
@@ -351,10 +422,44 @@ func streamLogStream(ctx context.Context, cwl *cloudwatchlogs.Client, logGroup, 
 		cancel()
 
 		if err != nil {
+			// Deleted or aged out of retention. Stop instead of retrying:
+			// the discovery loop restarts this stream if it reappears.
+			var missing *types.ResourceNotFoundException
+			if errors.As(err, &missing) {
+				catcher.Info("Log stream or group no longer exists, stopping", map[string]any{
+					"logGroup":   logGroup,
+					"stream":     streamName,
+					"totalCount": processedCount,
+					"process":    processName,
+				})
+				cursors.delete(streamName)
+				return
+			}
+
+			// NextForwardToken expires after 24 hours, and CloudWatch then
+			// rejects it as InvalidParameterException. Dropping it falls
+			// back to StartTime, re-reading an overlap rather than stranding
+			// the stream. The sentToken guard bounds this to one immediate
+			// retry; discarding on every rejection would hot-loop the API.
+			var badParam *types.InvalidParameterException
+			if sentToken != nil && errors.As(err, &badParam) {
+				_ = catcher.Error("log stream cursor rejected, falling back to the time floor", err, map[string]any{
+					"logGroup":  logGroup,
+					"stream":    streamName,
+					"startTime": startTime.Format(time.RFC3339),
+					"process":   processName,
+				})
+				nextToken = nil
+				if ctx.Err() == nil {
+					cursors.set(streamName, nil)
+				}
+				continue
+			}
+
 			_ = catcher.Error("cannot get log events", err, map[string]any{
 				"logGroup": logGroup,
 				"stream":   streamName,
-				"process":  "plugin_com.utmstack.aws",
+				"process":  processName,
 			})
 			if !sleepWithCancel(ctx, 10*time.Second) {
 				return
@@ -365,13 +470,13 @@ func streamLogStream(ctx context.Context, cwl *cloudwatchlogs.Client, logGroup, 
 		eventsInBatch := 0
 		for _, event := range result.Events {
 			_ = plugins.EnqueueLog(&plugins.Log{
-				Id:         uuid.NewString(),
+				Id:         eventIdentity(groupKey, logGroup, streamName, *event.Timestamp, *event.Message),
 				TenantId:   tenantId,
 				DataType:   "aws",
 				DataSource: dataSource,
 				Timestamp:  time.Now().UTC().Format(time.RFC3339Nano),
 				Raw:        *event.Message,
-			}, "com.utmstack.aws")
+			}, pluginName)
 			processedCount++
 			eventsInBatch++
 		}
@@ -382,16 +487,41 @@ func streamLogStream(ctx context.Context, cwl *cloudwatchlogs.Client, logGroup, 
 				"batchCount": eventsInBatch,
 				"totalCount": processedCount,
 				"dataSource": dataSource,
-				"process":    "plugin_com.utmstack.aws",
+				"process":    processName,
 			})
 		}
 
+		// A nil sentToken is the first call on an unseeded stream and can
+		// never match, so it must not count as end of stream.
+		atEnd := false
 		if result.NextForwardToken != nil {
+			atEnd = sentToken != nil && *sentToken == *result.NextForwardToken
 			nextToken = result.NextForwardToken
-		} else {
-			if !sleepWithCancel(ctx, 5*time.Second) {
-				return
+			// Skip if already cancelled, so a pruned entry is not resurrected.
+			if ctx.Err() == nil {
+				cursors.set(streamName, nextToken)
 			}
+		} else {
+			// No token to advance to, so there is nothing to poll forward.
+			atEnd = true
+		}
+
+		if eventsInBatch > 0 {
+			idleWait = idlePollBase
+		}
+
+		if !atEnd {
+			// The token moved, so poll again immediately even on an empty
+			// page: a sparse region returns those while still catching up.
+			continue
+		}
+
+		if !sleepWithCancel(ctx, idleWait) {
+			return
+		}
+		idleWait *= 2
+		if idleWait > idlePollMax {
+			idleWait = idlePollMax
 		}
 	}
 }
@@ -428,7 +558,7 @@ func checkConnection(url string) error {
 	defer func() {
 		err := resp.Body.Close()
 		if err != nil {
-			_ = catcher.Error("error closing response body: %v", err, map[string]any{"process": "plugin_com.utmstack.aws"})
+			_ = catcher.Error("error closing response body: %v", err, map[string]any{"process": processName})
 		}
 	}()
 
@@ -442,7 +572,7 @@ func infiniteRetryIfXError(f func() error, exception string) error {
 		err := f()
 		if err != nil && is(err, exception) {
 			if !xErrorWasLogged {
-				_ = catcher.Error("An error occurred (%s), will keep retrying indefinitely...", err, map[string]any{"process": "aws-plugin"})
+				_ = catcher.Error("An error occurred (%s), will keep retrying indefinitely...", err, map[string]any{"process": processName})
 				xErrorWasLogged = true
 			}
 			time.Sleep(wait)

--- a/plugins/crowdstrike/appid.go
+++ b/plugins/crowdstrike/appid.go
@@ -1,0 +1,15 @@
+package main
+
+import "github.com/utmstack/UTMStack/plugins/shared/identity"
+
+// CrowdStrike caps the appId query parameter at 32 alphanumeric characters.
+// Truncating to 32 hex characters keeps 128 bits, ample to keep units distinct.
+const appIDLength = 32
+
+// deriveAppID derives the CrowdStrike appId for one owned unit. An appId names a
+// server-side subscription carrying its own offset, so it must be stable per
+// unit: a distinct appId per process opens an independent copy of the whole feed
+// rather than distributing it. groupKey must be passed through unmodified.
+func deriveAppID(groupKey string) string {
+	return identity.Hash(groupKey)[:appIDLength]
+}

--- a/plugins/crowdstrike/config.go
+++ b/plugins/crowdstrike/config.go
@@ -1,10 +1,6 @@
 package main
 
 import (
-	"crypto/aes"
-	"crypto/cipher"
-	"crypto/sha1"
-	"encoding/base64"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -14,13 +10,14 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/threatwinds/go-sdk/catcher"
 	"github.com/threatwinds/go-sdk/plugins"
-	"golang.org/x/crypto/pbkdf2"
+	"github.com/utmstack/UTMStack/plugins/shared/crypto"
 	"gopkg.in/yaml.v3"
 )
 
 const (
 	pluginFile         = "system_plugins_crowdstrike.yaml"
-	processName        = "plugin_com.utmstack.crowdstrike"
+	pluginName         = "com.utmstack.crowdstrike"
+	processName        = "plugin_" + pluginName
 	pipelineDirDefault = "/workdir/pipeline"
 )
 
@@ -68,8 +65,7 @@ func GetConfigUpdateChannel() <-chan *ConfigurationSection {
 	return configUpdateChan
 }
 
-// StartConfigurationSystem starts the file watcher. Blocks until configured,
-// then runs indefinitely.
+// StartConfigurationSystem blocks until configured, then watches indefinitely.
 func StartConfigurationSystem() {
 	pipelineDir := pipelineDirDefault
 	var encKey string
@@ -88,7 +84,6 @@ func StartConfigurationSystem() {
 
 	filePath := filepath.Join(pipelineDir, pluginFile)
 
-	// Initial load.
 	if sec := readConfig(filePath, encKey); sec != nil {
 		mu.Lock()
 		cnf = sec
@@ -140,7 +135,6 @@ func StartConfigurationSystem() {
 	}
 }
 
-// pollFallback is used if fsnotify setup fails — polls every 30s instead.
 func pollFallback(filePath, encKey string) {
 	catcher.Warn("falling back to 30s polling", map[string]any{"process": processName})
 	for range time.Tick(30 * time.Second) {
@@ -187,8 +181,7 @@ func readConfig(path, encKey string) *ConfigurationSection {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			// File removed → module disabled / no configuration. Report an empty,
-			// inactive section so the module is treated as disabled and all work stops.
+			// An inactive section stops all work; nil means "keep the current config".
 			return &ConfigurationSection{ModuleActive: false}
 		}
 		_ = catcher.Error("failed to read config file", err, map[string]any{"process": processName, "file": path})
@@ -215,7 +208,7 @@ func readConfig(path, encKey string) *ConfigurationSection {
 			for k, v := range g.Config {
 				conf := &Configuration{ConfKey: k, ConfValue: v}
 				if encKey != "" && sensitiveKeys[conf.ConfKey] {
-					dec, err := NewCipher(encKey).Decrypt(conf.ConfValue)
+					dec, err := crypto.NewCipher(encKey).Decrypt(conf.ConfValue)
 					if err == nil {
 						conf.ConfValue = dec
 					}
@@ -225,64 +218,6 @@ func readConfig(path, encKey string) *ConfigurationSection {
 			sec.ModuleGroups = append(sec.ModuleGroups, grp)
 		}
 	}
-	// A tenant section with no groups must not read as configured.
 	sec.ModuleActive = len(sec.ModuleGroups) > 0
 	return sec
-}
-
-const (
-	iterationCount = 65536
-	keyLength      = 16
-)
-
-type Cipher struct {
-	key []byte
-}
-
-func NewCipher(key string) *Cipher {
-	return &Cipher{key: []byte(key)}
-}
-
-func (c *Cipher) setKey() (cipher.Block, []byte, error) {
-	h := sha1.New()
-	h.Write(c.key)
-	salt := h.Sum(nil)
-	keyEnc := pbkdf2.Key(c.key, salt, iterationCount, keyLength, sha1.New)
-	block, err := aes.NewCipher(keyEnc)
-	if err != nil {
-		return nil, nil, err
-	}
-	return block, salt[:keyLength], nil
-}
-
-func (c *Cipher) Decrypt(crypt string) (string, error) {
-	if crypt == "" {
-		return "", nil
-	}
-	encryptedData, err := base64.StdEncoding.DecodeString(crypt)
-	if err != nil {
-		return crypt, nil // not base64 → already plaintext
-	}
-	blk, iv, err := c.setKey()
-	if err != nil {
-		return crypt, err
-	}
-	if len(encryptedData)%aes.BlockSize != 0 {
-		return crypt, nil // not a valid CBC block → already plaintext
-	}
-	dec := cipher.NewCBCDecrypter(blk, iv)
-	decrypted := make([]byte, len(encryptedData))
-	dec.CryptBlocks(decrypted, encryptedData)
-	return string(pkcs5Trim(decrypted)), nil
-}
-
-func pkcs5Trim(data []byte) []byte {
-	if len(data) == 0 {
-		return data
-	}
-	padding := int(data[len(data)-1])
-	if padding > len(data) || padding == 0 {
-		return data
-	}
-	return data[:len(data)-padding]
 }

--- a/plugins/crowdstrike/cursor.go
+++ b/plugins/crowdstrike/cursor.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"time"
+
+	"github.com/utmstack/UTMStack/plugins/shared/coordination"
+)
+
+// cursorSnapshot is the payload persisted per unit. StartTime is the event-time
+// floor in Unix milliseconds; it must be persisted with the offsets, not
+// recomputed on activation, or resuming filters out the backlog they exist for.
+type cursorSnapshot struct {
+	StartTime uint64            `json:"startTime"`
+	Offsets   map[string]uint64 `json:"offsets"`
+}
+
+type cursorState struct {
+	mu        sync.Mutex
+	startTime uint64
+	offsets   map[string]uint64
+}
+
+// newCursorState returns an unseeded state; only activateCursor may seed it.
+func newCursorState() *cursorState {
+	return &cursorState{offsets: make(map[string]uint64)}
+}
+
+func (c *cursorState) seedFromNow(now time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.startTime = uint64(now.UnixMilli())
+	c.offsets = make(map[string]uint64)
+}
+
+func (c *cursorState) restore(s cursorSnapshot) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.startTime = s.StartTime
+	c.offsets = make(map[string]uint64, len(s.Offsets))
+	for feed, offset := range s.Offsets {
+		c.offsets[feed] = offset
+	}
+}
+
+func (c *cursorState) setOffset(feed string, offset uint64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.offsets[feed] = offset
+}
+
+// offset returns the feed's resume point, zero if never consumed. Zero makes
+// gofalcon omit the offset parameter entirely, safe only because the event-time
+// floor still bounds what the feed then delivers.
+func (c *cursorState) offset(feed string) uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.offsets[feed]
+}
+
+// startsAfter returns the event-time floor in Unix milliseconds.
+func (c *cursorState) startsAfter() uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.startTime
+}
+
+func (c *cursorState) snapshot() cursorSnapshot {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	out := cursorSnapshot{StartTime: c.startTime, Offsets: make(map[string]uint64, len(c.offsets))}
+	for feed, offset := range c.offsets {
+		out.Offsets[feed] = offset
+	}
+	return out
+}
+
+// marshalSnapshot implements coordination.CursorSnapshot.
+func (c *cursorState) marshalSnapshot() ([]byte, error) {
+	return json.Marshal(c.snapshot())
+}
+
+// activateCursor establishes a newly owned unit's position and returns the
+// revision its heartbeat must continue from. A fresh seed is persisted before
+// any event is consumed, so a crash before the first heartbeat does not make the
+// successor reseed and skip whatever arrived in between.
+func activateCursor(ctx context.Context, cursors coordination.CursorStore, key string, state *cursorState, now time.Time) (uint64, error) {
+	var persisted cursorSnapshot
+
+	rev, found, err := coordination.LoadCursorInto(ctx, cursors, key, &persisted)
+	if err != nil {
+		// Fail closed: seeding from now would look like a clean start while
+		// silently skipping everything since the last understood position.
+		return rev, err
+	}
+
+	// A zero StartTime is unusable, not adoptable: it would emit every event
+	// CrowdStrike still retains.
+	if found && persisted.StartTime != 0 {
+		state.restore(persisted)
+		return rev, nil
+	}
+
+	state.seedFromNow(now)
+
+	data, err := state.marshalSnapshot()
+	if err != nil {
+		return rev, err
+	}
+
+	saved, err := cursors.Save(ctx, key, coordination.Cursor{Data: data, Revision: rev})
+	if err != nil {
+		// The unit still runs: the floor is set in memory, so nothing historical
+		// is emitted. Only durability is delayed to the first heartbeat.
+		return rev, err
+	}
+
+	return saved.Revision, nil
+}

--- a/plugins/crowdstrike/go.mod
+++ b/plugins/crowdstrike/go.mod
@@ -7,9 +7,11 @@ require (
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/google/uuid v1.6.0
 	github.com/threatwinds/go-sdk v1.1.28
-	golang.org/x/crypto v0.55.0
+	github.com/utmstack/UTMStack/plugins/shared v0.0.0-00010101000000-000000000000
 	gopkg.in/yaml.v3 v3.0.1
 )
+
+replace github.com/utmstack/UTMStack/plugins/shared => ../shared
 
 require (
 	cel.dev/expr v0.25.2 // indirect
@@ -56,11 +58,15 @@ require (
 	github.com/google/cel-go v0.28.1 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/nats-io/nats.go v1.53.1 // indirect
+	github.com/nats-io/nkeys v0.4.15 // indirect
+	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/opensearch-project/opensearch-go/v4 v4.6.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.3.1 // indirect
@@ -81,6 +87,7 @@ require (
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/arch v0.27.0 // indirect
+	golang.org/x/crypto v0.55.0 // indirect
 	golang.org/x/exp v0.0.0-20260603202125-055de637280b // indirect
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect

--- a/plugins/crowdstrike/go.sum
+++ b/plugins/crowdstrike/go.sum
@@ -110,6 +110,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBFW2IE=
+github.com/klauspost/compress v1.18.5/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
 github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -125,6 +127,12 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/nats-io/nats.go v1.53.1 h1:Otsq3uLc/kLdjmkNHkXH0jBqwUquwdKFoe3fq6/3/Xo=
+github.com/nats-io/nats.go v1.53.1/go.mod h1:26HypzazeOkyO3/mqd1zZd53STJN0EjCYF9Uy2ZOBno=
+github.com/nats-io/nkeys v0.4.15 h1:JACV5jRVO9V856KOapQ7x+EY8Jo3qw1vJt/9Jpwzkk4=
+github.com/nats-io/nkeys v0.4.15/go.mod h1:CpMchTXC9fxA5zrMo4KpySxNjiDVvr8ANOSZdiNfUrs=
+github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=
+github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/opensearch-project/opensearch-go/v4 v4.6.0 h1:Ac8aLtDSmLEyOmv0r1qhQLw3b4vcUhE42NE9k+Z4cRc=

--- a/plugins/crowdstrike/heartbeat.go
+++ b/plugins/crowdstrike/heartbeat.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"errors"
+
+	"github.com/threatwinds/go-sdk/catcher"
+	"github.com/utmstack/UTMStack/plugins/shared/coordination"
+)
+
+// groupHeartbeat builds the heartbeat for one unit. cancel must cancel the
+// context processStreamEvents is parked on: fencing relies on it to cut the open
+// Falcon socket, or this worker keeps reading a feed another worker now owns.
+func groupHeartbeat(coord coordination.LeasePath, cursorKey string, cursor *cursorState, cancel context.CancelFunc) coordination.Heartbeat {
+	return coordination.Heartbeat{
+		Leases:   coord.Leases,
+		Cursors:  coord.Cursors,
+		Key:      cursorKey,
+		Snapshot: cursor.marshalSnapshot,
+		TTL:      coordination.LeaseTTL,
+		Interval: coordination.HeartbeatInterval,
+		Cancel:   cancel,
+		OnError:  reportHeartbeatFailure(cursorKey),
+	}
+}
+
+func reportHeartbeatFailure(cursorKey string) func(error) {
+	return func(err error) {
+		if errors.Is(err, coordination.ErrFenced) {
+			catcher.Info("lease fenced, cutting this unit's event stream", map[string]any{
+				"process": processName,
+				"key":     cursorKey,
+			})
+			return
+		}
+
+		_ = catcher.Error("failed to persist the offsets snapshot, will retry next heartbeat", err, map[string]any{
+			"process": processName,
+			"key":     cursorKey,
+		})
+	}
+}

--- a/plugins/crowdstrike/identity.go
+++ b/plugins/crowdstrike/identity.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"strconv"
+
+	"github.com/utmstack/UTMStack/plugins/shared/identity"
+)
+
+// eventIdentity derives a deterministic identity for one Falcon streaming
+// event. event.Metadata.Offset is a per-subscription sequence number, unique
+// only within a tenant, so tenant and group must be hashed too: otherwise two
+// tenants each running a group named "prod" would collide.
+func eventIdentity(tenantId, groupKey, streamID string, offset uint64) string {
+	return identity.Hash(tenantId, groupKey, streamID, strconv.FormatUint(offset, 10))
+}

--- a/plugins/crowdstrike/lease.go
+++ b/plugins/crowdstrike/lease.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"time"
+
+	"github.com/threatwinds/go-sdk/catcher"
+	"github.com/utmstack/UTMStack/plugins/shared/coordination"
+)
+
+// leaseKeyPrefix namespaces this plugin's keys inside the shared lease bucket.
+// The rest of the key is ModuleGroup.Key() passed through unmodified.
+const leaseKeyPrefix = "crowdstrike."
+
+// runOwnedStream blocks until this worker owns the unit's lease, then calls run
+// synchronously. The caller must already be in the unit's own goroutine.
+func runOwnedStream(coord coordination.LeasePath, holder string, stream *activeStream, run func(*activeStream)) {
+	key := leaseKeyPrefix + stream.groupKey
+
+	lease, err := coordination.AcquireWithRetry(
+		stream.ctx, coord.Leases, key, holder,
+		coordination.LeaseTTL, coordination.AcquireRetryInterval,
+		func(err error) {
+			_ = catcher.Error("failed to acquire the unit's lease", err, map[string]any{
+				"process": processName,
+				"key":     key,
+			})
+		},
+	)
+	if err != nil {
+		// Stopped before it was ever owned; no socket to unwind.
+		return
+	}
+
+	logLeaseAcquired(key, holder)
+
+	cursorRev, err := activateCursor(stream.ctx, coord.Cursors, key, stream.cursor, time.Now())
+	if err != nil {
+		_ = catcher.Error("failed to establish the unit's starting position", err, map[string]any{
+			"process": processName,
+			"key":     key,
+		})
+	}
+
+	// No floor means no usable position; opening the feed would emit everything
+	// CrowdStrike still retains. Released, not abandoned, so another worker can
+	// retry without waiting out the TTL.
+	if stream.cursor.startsAfter() == 0 {
+		_ = catcher.Error("refusing to open the event stream without a starting position", err, map[string]any{
+			"process": processName,
+			"key":     key,
+		})
+		_ = coord.Leases.Release(stream.ctx, lease)
+		stream.cancel()
+		return
+	}
+
+	logStartingPosition(key, stream.cursor.startsAfter())
+
+	go groupHeartbeat(coord, key, stream.cursor, stream.cancel).Run(stream.ctx, lease, cursorRev)
+
+	run(stream)
+}

--- a/plugins/crowdstrike/main.go
+++ b/plugins/crowdstrike/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/threatwinds/go-sdk/catcher"
 	"github.com/threatwinds/go-sdk/plugins"
+	"github.com/utmstack/UTMStack/plugins/shared/coordination"
 )
 
 const (
@@ -28,14 +29,15 @@ const (
 )
 
 type activeStream struct {
-	ctx             context.Context
-	cancel          context.CancelFunc
-	processor       *CrowdStrikeProcessor
-	dataSource      string
-	offsets         map[string]uint64
-	streamStartTime uint64
-	wg              sync.WaitGroup
-	mu              sync.Mutex
+	ctx       context.Context
+	cancel    context.CancelFunc
+	processor *CrowdStrikeProcessor
+	// groupKey is ModuleGroup.Key() stored unmodified: the lease key, cursor key
+	// and event identities are all derived from it.
+	groupKey   string
+	dataSource string
+	cursor     *cursorState
+	wg         sync.WaitGroup
 }
 
 var (
@@ -43,15 +45,18 @@ var (
 	activeStreamsMu sync.RWMutex
 )
 
+// coordinationRetryDelay paces retries while coordination is unreachable.
+const coordinationRetryDelay = 5 * time.Second
+
 func main() {
-	mode := plugins.GetCfg("plugin_com.utmstack.crowdstrike").Env.Mode
-	if mode != "manager" {
+	mode := plugins.GetCfg(processName).Env.Mode
+	if mode != "worker" {
 		return
 	}
 
 	if err := connectionChecker(urlCheckConnection); err != nil {
 		_ = catcher.Error("Failed to establish connectivity, plugin will not start", err, map[string]any{
-			"process": "plugin_com.utmstack.crowdstrike",
+			"process": processName,
 		})
 		return
 	}
@@ -60,21 +65,43 @@ func main() {
 
 	for i := 0; i < 2*runtime.NumCPU(); i++ {
 		go func() {
-			plugins.SendLogsFromChannel("com.utmstack.crowdstrike")
+			plugins.SendLogsFromChannel(pluginName)
 		}()
 	}
 
-	go watchConfigurationChanges()
+	ctx := context.Background()
+
+	// Blocks until coordination succeeds and never falls back to ingesting
+	// without it: an appId names one server-side subscription, so two workers on
+	// the same unit would fight over it instead of splitting the feed.
+	setup, err := coordination.SetupWithRetry(ctx, coordination.DialLeasePath(processName), coordinationRetryDelay, func(err error) {
+		_ = catcher.Error("coordination setup failed, waiting to retry", err, map[string]any{
+			"process": processName,
+		})
+	})
+	if err != nil {
+		// Only reachable if ctx is cancelled; production passes Background().
+		_ = catcher.Error("coordination setup cancelled before it could succeed", err, map[string]any{
+			"process": processName,
+		})
+		return
+	}
+	defer setup.Close()
+
+	holder := uuid.NewString()
+	logCoordinationReady(holder)
+
+	go watchConfigurationChanges(ctx, setup, holder)
 
 	select {}
 }
 
-func watchConfigurationChanges() {
+func watchConfigurationChanges(ctx context.Context, coord coordination.LeasePath, holder string) {
 	time.Sleep(3 * time.Second)
 
 	initialConfig := GetConfig()
 	if initialConfig != nil && initialConfig.ModuleActive {
-		updateStreams(initialConfig)
+		updateStreams(ctx, coord, holder, initialConfig)
 	}
 
 	for newConfig := range GetConfigUpdateChannel() {
@@ -83,11 +110,11 @@ func watchConfigurationChanges() {
 			continue
 		}
 
-		updateStreams(newConfig)
+		updateStreams(ctx, coord, holder, newConfig)
 	}
 }
 
-func updateStreams(newConfig *ConfigurationSection) {
+func updateStreams(ctx context.Context, coord coordination.LeasePath, holder string, newConfig *ConfigurationSection) {
 	activeStreamsMu.Lock()
 	defer activeStreamsMu.Unlock()
 
@@ -125,33 +152,35 @@ func updateStreams(newConfig *ConfigurationSection) {
 					s.wg.Wait()
 					activeStreamsMu.Lock()
 					delete(activeStreams, k)
-					startStream(k, g)
+					startStream(ctx, coord, holder, k, g)
 					activeStreamsMu.Unlock()
 				}(existingStream, key, group)
 			}
 		} else {
-			startStream(key, group)
+			startStream(ctx, coord, holder, key, group)
 		}
 	}
 }
 
-func startStream(key string, group *ModuleGroup) {
-	ctx, cancel := context.WithCancel(context.Background())
-
-	processor := buildProcessor(group)
+// startStream registers a unit; nothing connects until runOwnedStream holds the
+// lease. ctx must be the plugin's root context so shutdown reaches every socket.
+func startStream(ctx context.Context, coord coordination.LeasePath, holder, key string, group *ModuleGroup) {
+	streamCtx, cancel := context.WithCancel(ctx)
 
 	stream := &activeStream{
-		ctx:             ctx,
-		cancel:          cancel,
-		processor:       processor,
-		dataSource:      group.GroupName,
-		offsets:         make(map[string]uint64),
-		streamStartTime: uint64(time.Now().UnixMilli()),
+		ctx:        streamCtx,
+		cancel:     cancel,
+		processor:  buildProcessor(group),
+		groupKey:   key,
+		dataSource: group.GroupName,
+		cursor:     newCursorState(),
 	}
 
 	activeStreams[key] = stream
 
-	go maintainStreamConnection(stream)
+	// Not tracked by stream.wg: runEventStream waits on that same WaitGroup for
+	// its feed goroutines, so adding this one would deadlock the unit.
+	go runOwnedStream(coord, holder, stream, maintainStreamConnection)
 }
 
 func stopAllStreams() {
@@ -203,7 +232,7 @@ func runEventStream(stream *activeStream) error {
 	apiClient, err := stream.processor.createClient()
 	if err != nil {
 		return catcher.Error("failed to create client", err, map[string]any{
-			"process": "plugin_com.utmstack.crowdstrike",
+			"process": processName,
 		})
 	}
 
@@ -213,20 +242,20 @@ func runEventStream(stream *activeStream) error {
 	jsonFormat := "json"
 	response, err := apiClient.EventStreams.ListAvailableStreamsOAuth2(
 		&event_streams.ListAvailableStreamsOAuth2Params{
-			AppID:   stream.processor.AppName,
+			AppID:   stream.processor.AppID,
 			Format:  &jsonFormat,
 			Context: ctx,
 		},
 	)
 	if err != nil {
 		return catcher.Error("failed to list streams", err, map[string]any{
-			"process": "plugin_com.utmstack.crowdstrike",
+			"process": processName,
 		})
 	}
 
 	if err = falcon.AssertNoError(response.Payload.Errors); err != nil {
 		return catcher.Error("CrowdStrike API error", err, map[string]any{
-			"process": "plugin_com.utmstack.crowdstrike",
+			"process": processName,
 		})
 	}
 
@@ -235,7 +264,7 @@ func runEventStream(stream *activeStream) error {
 	for _, streamV2 := range availableStreams {
 		if streamV2.DataFeedURL == nil {
 			catcher.Error("Stream has nil DataFeedURL, skipping", nil, map[string]any{
-				"process": "plugin_com.utmstack.crowdstrike",
+				"process": processName,
 			})
 			continue
 		}
@@ -264,22 +293,22 @@ func maintainIndividualStream(stream *activeStream, apiClient *client.CrowdStrik
 		case <-stream.ctx.Done():
 			return
 		default:
-			stream.mu.Lock()
-			currentOffset := stream.offsets[streamID]
-			stream.mu.Unlock()
+			currentOffset := stream.cursor.offset(streamID)
 
-			falconStream, err := falcon.NewStream(stream.ctx, apiClient, stream.processor.AppName, streamResource, currentOffset)
+			falconStream, err := falcon.NewStream(stream.ctx, apiClient, stream.processor.AppID, streamResource, currentOffset)
 			if err != nil {
 				catcher.Error("failed to create stream, will retry", err, map[string]any{
-					"process": "plugin_com.utmstack.crowdstrike",
+					"process": processName,
 				})
 			} else {
+				logStreamOpened(stream.groupKey, streamID, currentOffset)
+
 				err = processStreamEvents(stream, falconStream, streamID)
 				falconStream.Close()
 
 				if err != nil {
 					catcher.Error("stream error, will reconnect", err, map[string]any{
-						"process": "plugin_com.utmstack.crowdstrike",
+						"process": processName,
 					})
 				}
 			}
@@ -297,6 +326,9 @@ func maintainIndividualStream(stream *activeStream, apiClient *client.CrowdStrik
 }
 
 func processStreamEvents(stream *activeStream, falconStream *falcon.StreamingHandle, streamID string) error {
+	// Scoped to one open socket, so each reconnect announces its first event.
+	var firstEvent firstEventGate
+
 	for {
 		select {
 		case <-stream.ctx.Done():
@@ -305,26 +337,28 @@ func processStreamEvents(stream *activeStream, falconStream *falcon.StreamingHan
 		case err := <-falconStream.Errors:
 			if err.Fatal {
 				return catcher.Error("fatal stream error", err.Err, map[string]any{
-					"process": "plugin_com.utmstack.crowdstrike",
+					"process": processName,
 				})
 			}
 			catcher.Error("Non-fatal stream error", err.Err, map[string]any{
-				"process": "plugin_com.utmstack.crowdstrike",
+				"process": processName,
 			})
 
 		case event := <-falconStream.Events:
-			if event.Metadata.EventCreationTime > stream.streamStartTime {
-				processEvent(event, stream.dataSource, stream.processor.TenantId)
+			if event.Metadata.EventCreationTime > stream.cursor.startsAfter() {
+				processEvent(event, stream.dataSource, stream.processor.TenantId, stream.groupKey, streamID)
 
-				stream.mu.Lock()
-				stream.offsets[streamID] = event.Metadata.Offset
-				stream.mu.Unlock()
+				stream.cursor.setOffset(streamID, event.Metadata.Offset)
+
+				if firstEvent.take() {
+					logFirstEventIngested(stream.groupKey, streamID, event.Metadata.Offset)
+				}
 			}
 		}
 	}
 }
 
-func processEvent(event *streaming_models.EventItem, dataSource string, tenantId string) {
+func processEvent(event *streaming_models.EventItem, dataSource string, tenantId string, groupKey string, streamID string) {
 	var eventData string
 	if len(event.RawMessage) > 0 {
 		eventData = string(event.RawMessage)
@@ -332,7 +366,7 @@ func processEvent(event *streaming_models.EventItem, dataSource string, tenantId
 		eventJSON, err := json.Marshal(event)
 		if err != nil {
 			catcher.Error("Failed to marshal event", err, map[string]any{
-				"process": "plugin_com.utmstack.crowdstrike",
+				"process": processName,
 			})
 			return
 		}
@@ -343,22 +377,26 @@ func processEvent(event *streaming_models.EventItem, dataSource string, tenantId
 		tenantId = defaultTenant
 	}
 
+	// Identity is derived after the defaultTenant substitution above, so it is
+	// scoped to the tenant the event is filed under.
 	_ = plugins.EnqueueLog(&plugins.Log{
-		Id:         uuid.NewString(),
+		Id:         eventIdentity(tenantId, groupKey, streamID, event.Metadata.Offset),
 		TenantId:   tenantId,
 		DataType:   "crowdstrike",
 		DataSource: dataSource,
 		Timestamp:  time.Now().UTC().Format(time.RFC3339Nano),
 		Raw:        eventData,
-	}, "com.utmstack.crowdstrike")
+	}, pluginName)
 }
 
 type CrowdStrikeProcessor struct {
 	ClientID     string
 	ClientSecret string
 	Cloud        string
-	AppName      string
-	TenantId     string
+	// AppID comes from deriveAppID, never from configuration: two groups sharing
+	// a CID and an administrator-chosen app name would share one subscription.
+	AppID    string
+	TenantId string
 }
 
 func isGroupValid(group *ModuleGroup) bool {
@@ -375,7 +413,10 @@ func isGroupValid(group *ModuleGroup) bool {
 }
 
 func buildProcessor(group *ModuleGroup) *CrowdStrikeProcessor {
-	processor := &CrowdStrikeProcessor{TenantId: group.TenantId}
+	processor := &CrowdStrikeProcessor{
+		TenantId: group.TenantId,
+		AppID:    deriveAppID(group.Key()),
+	}
 
 	for _, cnf := range group.ModuleGroupConfigurations {
 		switch cnf.ConfKey {
@@ -385,8 +426,6 @@ func buildProcessor(group *ModuleGroup) *CrowdStrikeProcessor {
 			processor.ClientSecret = cnf.ConfValue
 		case "crowdstrike_cloud_region_url":
 			processor.Cloud = cnf.ConfValue
-		case "crowdstrike_app_name":
-			processor.AppName = cnf.ConfValue
 		}
 	}
 	return processor
@@ -399,20 +438,20 @@ func processorChanged(old, new *CrowdStrikeProcessor) bool {
 	return old.ClientID != new.ClientID ||
 		old.ClientSecret != new.ClientSecret ||
 		old.Cloud != new.Cloud ||
-		old.AppName != new.AppName ||
+		old.AppID != new.AppID ||
 		old.TenantId != new.TenantId
 }
 
 func (p *CrowdStrikeProcessor) createClient() (*client.CrowdStrikeAPISpecification, error) {
 	if p.ClientID == "" || p.ClientSecret == "" {
 		return nil, catcher.Error("cannot create CrowdStrike client",
-			errors.New("client ID or client secret is empty"), map[string]any{"process": "plugin_com.utmstack.crowdstrike"})
+			errors.New("client ID or client secret is empty"), map[string]any{"process": processName})
 	}
 
 	cloudType, err := extractCloudFromURL(p.Cloud)
 	if err != nil {
 		return nil, catcher.Error("invalid cloud region configuration", err, map[string]any{
-			"process":     "plugin_com.utmstack.crowdstrike",
+			"process":     processName,
 			"cloud_value": p.Cloud,
 		})
 	}
@@ -424,7 +463,7 @@ func (p *CrowdStrikeProcessor) createClient() (*client.CrowdStrikeAPISpecificati
 		Context:      context.Background(),
 	})
 	if err != nil {
-		return nil, catcher.Error("cannot create CrowdStrike client", err, map[string]any{"process": "plugin_com.utmstack.crowdstrike"})
+		return nil, catcher.Error("cannot create CrowdStrike client", err, map[string]any{"process": processName})
 	}
 
 	return client, nil
@@ -485,7 +524,7 @@ func checkConnection(url string) error {
 	defer func() {
 		err := resp.Body.Close()
 		if err != nil {
-			_ = catcher.Error("error closing response body: %v", err, map[string]any{"process": "plugin_com.utmstack.crowdstrike"})
+			_ = catcher.Error("error closing response body: %v", err, map[string]any{"process": processName})
 		}
 	}()
 
@@ -499,7 +538,7 @@ func infiniteRetryIfXError(f func() error, exception string) error {
 		err := f()
 		if err != nil && is(err, exception) {
 			if !xErrorWasLogged {
-				_ = catcher.Error("An error occurred (%s), will keep retrying indefinitely...", err, map[string]any{"process": "plugin_com.utmstack.crowdstrike"})
+				_ = catcher.Error("An error occurred (%s), will keep retrying indefinitely...", err, map[string]any{"process": processName})
 				xErrorWasLogged = true
 			}
 			time.Sleep(reconnectDelay)

--- a/plugins/crowdstrike/observability.go
+++ b/plugins/crowdstrike/observability.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"time"
+
+	"github.com/threatwinds/go-sdk/catcher"
+	"github.com/utmstack/UTMStack/plugins/shared/coordination"
+)
+
+// Every INFO line this plugin emits must be tied to a state transition bounded
+// per unit: nothing per event, nothing on a fixed timer, or a real failure
+// becomes indistinguishable from normal operation.
+const (
+	coordinationReadyMsg = "coordination ready, owning units by lease"
+	leaseAcquiredMsg     = "unit lease acquired, this worker owns the unit"
+	startingPositionMsg  = "starting position established"
+	streamOpenedMsg      = "event stream opened"
+	firstEventMsg        = "first event ingested"
+)
+
+// logCoordinationReady announces that the lease path came up. holder is the only
+// value mapping a key held on the server back to a running worker.
+func logCoordinationReady(holder string) {
+	catcher.Info(coordinationReadyMsg, map[string]any{
+		"process":      processName,
+		"holder":       holder,
+		"leasePrefix":  leaseKeyPrefix,
+		"leaseBucket":  coordination.LeaseBucketName,
+		"cursorBucket": coordination.CursorBucketName,
+	})
+}
+
+// logLeaseAcquired announces that this worker now owns a unit. Call once per
+// acquisition, never per renewal: the heartbeat renews every few seconds.
+func logLeaseAcquired(key, holder string) {
+	catcher.Info(leaseAcquiredMsg, map[string]any{
+		"process": processName,
+		"key":     key,
+		"holder":  holder,
+	})
+}
+
+// logStartingPosition takes startsAfter in Unix milliseconds. Call it after the
+// zero-floor guard: the line must not claim a position for a unit about to
+// refuse to open.
+func logStartingPosition(key string, startsAfter uint64) {
+	catcher.Info(startingPositionMsg, map[string]any{
+		"process":     processName,
+		"key":         key,
+		"startsAfter": time.UnixMilli(int64(startsAfter)).UTC().Format(time.RFC3339Nano),
+	})
+}
+
+// streamID is the feed's DataFeedURL, safe to log: CrowdStrike carries the
+// session token in a separate field of the stream resource, so the URL holds no
+// credential.
+func logStreamOpened(groupKey, streamID string, offset uint64) {
+	catcher.Info(streamOpenedMsg, map[string]any{
+		"process":  processName,
+		"key":      groupKey,
+		"streamID": streamID,
+		"offset":   offset,
+	})
+}
+
+// firstEventGate lets one event per stream session announce itself. No mutex: it
+// must stay on the stack of the single goroutine running processStreamEvents.
+// Keep it per session, not process-wide, or reconnects go unreported.
+type firstEventGate struct {
+	announced bool
+}
+
+func (g *firstEventGate) take() bool {
+	if g.announced {
+		return false
+	}
+	g.announced = true
+	return true
+}
+
+// Call only for an event that passed the floor filter and was enqueued, so the
+// line reports ingestion rather than mere delivery.
+func logFirstEventIngested(groupKey, streamID string, offset uint64) {
+	catcher.Info(firstEventMsg, map[string]any{
+		"process":  processName,
+		"key":      groupKey,
+		"streamID": streamID,
+		"offset":   offset,
+	})
+}

--- a/plugins/o365/config.go
+++ b/plugins/o365/config.go
@@ -1,10 +1,6 @@
 package main
 
 import (
-	"crypto/aes"
-	"crypto/cipher"
-	"crypto/sha1"
-	"encoding/base64"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -14,13 +10,14 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/threatwinds/go-sdk/catcher"
 	"github.com/threatwinds/go-sdk/plugins"
-	"golang.org/x/crypto/pbkdf2"
+	"github.com/utmstack/UTMStack/plugins/shared/crypto"
 	"gopkg.in/yaml.v3"
 )
 
 const (
 	pluginFile         = "system_plugins_o365.yaml"
-	processName        = "plugin_com.utmstack.o365"
+	pluginName         = "com.utmstack.o365"
+	processName        = "plugin_" + pluginName
 	pipelineDirDefault = "/workdir/pipeline"
 )
 
@@ -47,7 +44,25 @@ var (
 	cnf              *ConfigurationSection
 	mu               sync.Mutex
 	configUpdateChan chan *ConfigurationSection
+
+	encKeyMu  sync.RWMutex
+	encKeyVal string
 )
+
+// The same key decrypts sensitive config values and encrypts the queue-path
+// cursor payload before it crosses NATS.
+func setEncryptionKey(key string) {
+	encKeyMu.Lock()
+	defer encKeyMu.Unlock()
+	encKeyVal = key
+}
+
+// Returns "" if no key has been configured yet.
+func getEncryptionKey() string {
+	encKeyMu.RLock()
+	defer encKeyMu.RUnlock()
+	return encKeyVal
+}
 
 func init() {
 	configUpdateChan = make(chan *ConfigurationSection, 1)
@@ -68,8 +83,7 @@ func GetConfigUpdateChannel() <-chan *ConfigurationSection {
 	return configUpdateChan
 }
 
-// StartConfigurationSystem starts the file watcher. Blocks until configured,
-// then runs indefinitely.
+// StartConfigurationSystem blocks until configured, then runs indefinitely.
 func StartConfigurationSystem() {
 	pipelineDir := pipelineDirDefault
 	var encKey string
@@ -80,6 +94,7 @@ func StartConfigurationSystem() {
 				pipelineDir = d
 			}
 			encKey = cfg.Get("encryptionKey").String()
+			setEncryptionKey(encKey)
 			break
 		}
 		_ = catcher.Error("plugin configuration not found", nil, map[string]any{"process": processName})
@@ -88,7 +103,6 @@ func StartConfigurationSystem() {
 
 	filePath := filepath.Join(pipelineDir, pluginFile)
 
-	// Initial load.
 	if sec := readConfig(filePath, encKey); sec != nil {
 		mu.Lock()
 		cnf = sec
@@ -104,7 +118,7 @@ func StartConfigurationSystem() {
 	}
 	defer watcher.Close()
 
-	// Watch the directory so we catch atomic write (rename) events.
+	// Watch the directory, not the file, so atomic writes (rename) are caught.
 	if err := watcher.Add(pipelineDir); err != nil {
 		_ = catcher.Error("failed to watch pipeline dir", err, map[string]any{"process": processName})
 		pollFallback(filePath, encKey)
@@ -140,7 +154,6 @@ func StartConfigurationSystem() {
 	}
 }
 
-// pollFallback is used if fsnotify setup fails — polls every 30s instead.
 func pollFallback(filePath, encKey string) {
 	catcher.Warn("falling back to 30s polling", map[string]any{"process": processName})
 	for range time.Tick(30 * time.Second) {
@@ -187,8 +200,8 @@ func readConfig(path, encKey string) *ConfigurationSection {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			// File removed → module disabled / no configuration. Report an empty,
-			// inactive section so the module is treated as disabled and all work stops.
+			// File removed means module disabled, not a read failure: return an
+			// inactive section so all work stops.
 			return &ConfigurationSection{ModuleActive: false}
 		}
 		_ = catcher.Error("failed to read config file", err, map[string]any{"process": processName, "file": path})
@@ -215,7 +228,7 @@ func readConfig(path, encKey string) *ConfigurationSection {
 			for k, v := range g.Config {
 				conf := &Configuration{ConfKey: k, ConfValue: v}
 				if sensitiveKeys[k] && encKey != "" {
-					dec, err := NewCipher(encKey).Decrypt(conf.ConfValue)
+					dec, err := crypto.NewCipher(encKey).Decrypt(conf.ConfValue)
 					if err == nil {
 						conf.ConfValue = dec
 					}
@@ -228,61 +241,4 @@ func readConfig(path, encKey string) *ConfigurationSection {
 	// A tenant section with no groups must not read as configured.
 	sec.ModuleActive = len(sec.ModuleGroups) > 0
 	return sec
-}
-
-const (
-	iterationCount = 65536
-	keyLength      = 16
-)
-
-type Cipher struct {
-	key []byte
-}
-
-func NewCipher(key string) *Cipher {
-	return &Cipher{key: []byte(key)}
-}
-
-func (c *Cipher) setKey() (cipher.Block, []byte, error) {
-	h := sha1.New()
-	h.Write(c.key)
-	salt := h.Sum(nil)
-	keyEnc := pbkdf2.Key(c.key, salt, iterationCount, keyLength, sha1.New)
-	block, err := aes.NewCipher(keyEnc)
-	if err != nil {
-		return nil, nil, err
-	}
-	return block, salt[:keyLength], nil
-}
-
-func (c *Cipher) Decrypt(crypt string) (string, error) {
-	if crypt == "" {
-		return "", nil
-	}
-	encryptedData, err := base64.StdEncoding.DecodeString(crypt)
-	if err != nil {
-		return crypt, nil // not base64 → already plaintext
-	}
-	blk, iv, err := c.setKey()
-	if err != nil {
-		return crypt, err
-	}
-	if len(encryptedData)%aes.BlockSize != 0 {
-		return crypt, nil // not a valid CBC block → already plaintext
-	}
-	dec := cipher.NewCBCDecrypter(blk, iv)
-	decrypted := make([]byte, len(encryptedData))
-	dec.CryptBlocks(decrypted, encryptedData)
-	return string(pkcs5Trim(decrypted)), nil
-}
-
-func pkcs5Trim(data []byte) []byte {
-	if len(data) == 0 {
-		return data
-	}
-	padding := int(data[len(data)-1])
-	if padding > len(data) || padding == 0 {
-		return data
-	}
-	return data[:len(data)-padding]
 }

--- a/plugins/o365/cursor.go
+++ b/plugins/o365/cursor.go
@@ -1,0 +1,16 @@
+package main
+
+import "time"
+
+// cursorKeyPrefix namespaces this plugin's keys in the shared bucket.
+const cursorKeyPrefix = "o365."
+
+func o365CursorKey(group *ModuleGroup) string {
+	return cursorKeyPrefix + group.Key()
+}
+
+// Boundary of the last successfully ingested window. CursorStore treats
+// Cursor.Data as opaque bytes and never parses this.
+type cursorPayload struct {
+	WindowEnd time.Time `json:"windowEnd"`
+}

--- a/plugins/o365/go.mod
+++ b/plugins/o365/go.mod
@@ -6,9 +6,11 @@ require (
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/google/uuid v1.6.0
 	github.com/threatwinds/go-sdk v1.1.28
-	golang.org/x/crypto v0.55.0
+	github.com/utmstack/UTMStack/plugins/shared v0.0.0
 	gopkg.in/yaml.v3 v3.0.1
 )
+
+replace github.com/utmstack/UTMStack/plugins/shared => ../shared
 
 require (
 	cel.dev/expr v0.25.2 // indirect
@@ -28,11 +30,15 @@ require (
 	github.com/google/cel-go v0.28.1 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/nats-io/nats.go v1.53.1 // indirect
+	github.com/nats-io/nkeys v0.4.15 // indirect
+	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/opensearch-project/opensearch-go/v4 v4.6.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.3.1 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
@@ -46,6 +52,7 @@ require (
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/arch v0.27.0 // indirect
+	golang.org/x/crypto v0.55.0 // indirect
 	golang.org/x/exp v0.0.0-20260603202125-055de637280b // indirect
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect

--- a/plugins/o365/go.sum
+++ b/plugins/o365/go.sum
@@ -53,6 +53,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBFW2IE=
+github.com/klauspost/compress v1.18.5/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
 github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -68,6 +70,12 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/nats-io/nats.go v1.53.1 h1:Otsq3uLc/kLdjmkNHkXH0jBqwUquwdKFoe3fq6/3/Xo=
+github.com/nats-io/nats.go v1.53.1/go.mod h1:26HypzazeOkyO3/mqd1zZd53STJN0EjCYF9Uy2ZOBno=
+github.com/nats-io/nkeys v0.4.15 h1:JACV5jRVO9V856KOapQ7x+EY8Jo3qw1vJt/9Jpwzkk4=
+github.com/nats-io/nkeys v0.4.15/go.mod h1:CpMchTXC9fxA5zrMo4KpySxNjiDVvr8ANOSZdiNfUrs=
+github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=
+github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/opensearch-project/opensearch-go/v4 v4.6.0 h1:Ac8aLtDSmLEyOmv0r1qhQLw3b4vcUhE42NE9k+Z4cRc=
 github.com/opensearch-project/opensearch-go/v4 v4.6.0/go.mod h1:3iZtb4SNt3IzaxavKq0dURh1AmtVgYW71E4XqmYnIiQ=
 github.com/pelletier/go-toml/v2 v2.3.1 h1:MYEvvGnQjeNkRF1qUuGolNtNExTDwct51yp7olPtrEc=

--- a/plugins/o365/identity.go
+++ b/plugins/o365/identity.go
@@ -1,0 +1,17 @@
+package main
+
+import "github.com/utmstack/UTMStack/plugins/shared/identity"
+
+// LogRecord is one ingested o365 audit record with its deterministic identity.
+type LogRecord struct {
+	ID  string
+	Raw string
+}
+
+// recordID is Microsoft's own per-record GUID, so the same source event always
+// hashes to the same identity, making a re-read recognisable. Nothing collapses
+// duplicates today: utmstack.logs ORDER BY excludes id, and alert dedup is
+// opt-in per rule. utmTenantId is redundant with groupKey but kept explicit.
+func eventIdentity(utmTenantId, groupKey, contentUri, recordID string) string {
+	return identity.Hash(utmTenantId, groupKey, contentUri, recordID)
+}

--- a/plugins/o365/main.go
+++ b/plugins/o365/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/threatwinds/go-sdk/catcher"
 	"github.com/threatwinds/go-sdk/plugins"
 	"github.com/threatwinds/go-sdk/utils"
+	"github.com/utmstack/UTMStack/plugins/shared/coordination"
 )
 
 type CloudEnvironment string
@@ -76,19 +77,42 @@ var (
 	activeGroups   = make(map[string]*ModuleGroup)
 )
 
+// coordinationRetryDelay paces retries while coordination is unreachable.
+const coordinationRetryDelay = 5 * time.Second
+
 func main() {
-	mode := plugins.GetCfg("plugin_com.utmstack.o365").Env.Mode
-	if mode != "manager" {
+	mode := plugins.GetCfg(processName).Env.Mode
+	if mode != "worker" {
 		return
 	}
 
 	go StartConfigurationSystem()
 
 	for i := 0; i < 2*runtime.NumCPU(); i++ {
-		go plugins.SendLogsFromChannel("com.utmstack.o365")
+		go plugins.SendLogsFromChannel(pluginName)
 	}
 
-	watchConfigAndPull()
+	ctx := context.Background()
+
+	// Blocks until NATS coordination is up. Fails closed: never ingests without
+	// coordination.
+	setup, err := coordination.SetupWithRetry(ctx, coordination.DialQueuePath(processName, queuePlugin), coordinationRetryDelay, func(err error) {
+		_ = catcher.Error("coordination setup failed, waiting to retry", err, map[string]any{
+			"process": processName,
+		})
+	})
+	if err != nil {
+		// Only reachable on ctx cancellation, which production never does; the
+		// branch exists so tests can kill the retry loop.
+		_ = catcher.Error("coordination setup cancelled before it could succeed", err, map[string]any{"process": processName})
+		return
+	}
+	defer setup.Close()
+	logCoordinationReady()
+
+	go runQueueConsumer(ctx, setup.Consumer, setup.Cursors, getEncryptionKey)
+
+	watchConfigAndPull(setup.Scheduler, setup.Publisher, uuid.New().String())
 }
 
 func syncActiveGroups(newConfig *ConfigurationSection) {
@@ -97,7 +121,7 @@ func syncActiveGroups(newConfig *ConfigurationSection) {
 
 	if newConfig == nil || !newConfig.ModuleActive {
 		catcher.Info("Module deactivated, clearing all groups", map[string]any{
-			"process": "plugin_com.utmstack.o365",
+			"process": processName,
 		})
 		activeGroups = make(map[string]*ModuleGroup)
 		return
@@ -112,7 +136,7 @@ func syncActiveGroups(newConfig *ConfigurationSection) {
 		if _, exists := newGroups[key]; !exists {
 			catcher.Info("Group removed from configuration", map[string]any{
 				"group":   key,
-				"process": "plugin_com.utmstack.o365",
+				"process": processName,
 			})
 		}
 	}
@@ -121,7 +145,7 @@ func syncActiveGroups(newConfig *ConfigurationSection) {
 		if _, exists := activeGroups[key]; !exists {
 			catcher.Info("New group added to configuration", map[string]any{
 				"group":   key,
-				"process": "plugin_com.utmstack.o365",
+				"process": processName,
 			})
 		}
 	}
@@ -140,7 +164,9 @@ func getActiveGroups() []*ModuleGroup {
 	return groups
 }
 
-func watchConfigAndPull() {
+// The local startTime below only seeds published jobs; authoritative per-group
+// progress lives in the persisted cursor, since another worker may handle a tick.
+func watchConfigAndPull(scheduler coordination.Store, publisher coordination.JobPublisher, holder string) {
 	time.Sleep(3 * time.Second)
 
 	initialConfig := GetConfig()
@@ -159,7 +185,7 @@ func watchConfigAndPull() {
 		case newConfig := <-GetConfigUpdateChannel():
 			catcher.Info("Received config update, syncing groups", map[string]any{
 				"moduleActive": newConfig != nil && newConfig.ModuleActive,
-				"process":      "plugin_com.utmstack.o365",
+				"process":      processName,
 			})
 			syncActiveGroups(newConfig)
 
@@ -169,7 +195,7 @@ func watchConfigAndPull() {
 			groups := getActiveGroups()
 			if len(groups) == 0 {
 				catcher.Info("No active groups, skipping pull", map[string]any{
-					"process": "plugin_com.utmstack.o365",
+					"process": processName,
 				})
 				startTime = endTime.Add(1 * time.Nanosecond)
 				continue
@@ -177,17 +203,8 @@ func watchConfigAndPull() {
 
 			checkConfiguredEnvironments(groups)
 
-			var wg sync.WaitGroup
-			wg.Add(len(groups))
+			publishTickJobs(context.Background(), scheduler, publisher, holder, groups, startTime, endTime)
 
-			for _, grp := range groups {
-				go func(group *ModuleGroup) {
-					defer wg.Done()
-					pull(startTime, endTime, group)
-				}(grp)
-			}
-
-			wg.Wait()
 			startTime = endTime.Add(1 * time.Nanosecond)
 		}
 	}
@@ -205,7 +222,7 @@ func checkConfiguredEnvironments(groups []*ModuleGroup) {
 	for authority, env := range uniqueAuthorities {
 		if err := ConnectionChecker(authority); err != nil {
 			_ = catcher.Error("External connection failure detected", err, map[string]any{
-				"process":     "plugin_com.utmstack.o365",
+				"process":     processName,
 				"environment": env,
 				"authority":   authority,
 			})
@@ -222,19 +239,20 @@ func getGroupEnvironment(group *ModuleGroup) CloudEnvironment {
 	return CloudCommercial
 }
 
-func pull(startTime time.Time, endTime time.Time, group *ModuleGroup) {
+// pull fetches one window of audit logs for group and enqueues them, returning
+// the record count. Callers must not advance the group's cursor when the error
+// is non-nil: that would skip past un-ingested data.
+func pull(startTime time.Time, endTime time.Time, group *ModuleGroup) (int, error) {
 	agent := GetOfficeProcessor(group)
 
-	err := agent.GetAuth()
-	if err != nil {
-		_ = catcher.Error("error getting auth", err, map[string]any{"process": "plugin_com.utmstack.o365"})
-		return
+	if err := agent.GetAuth(); err != nil {
+		_ = catcher.Error("error getting auth", err, map[string]any{"process": processName})
+		return 0, err
 	}
 
-	err = agent.StartSubscriptions()
-	if err != nil {
-		_ = catcher.Error("error starting subscriptions", err, map[string]any{"process": "plugin_com.utmstack.o365"})
-		return
+	if err := agent.StartSubscriptions(); err != nil {
+		_ = catcher.Error("error starting subscriptions", err, map[string]any{"process": processName})
+		return 0, err
 	}
 
 	utmTenantId := agent.UtmTenantId
@@ -242,24 +260,24 @@ func pull(startTime time.Time, endTime time.Time, group *ModuleGroup) {
 		utmTenantId = DefaultTenant
 	}
 
-	logs := agent.GetLogs(startTime, endTime)
-	for _, log := range logs {
+	records := agent.GetLogs(startTime, endTime, group)
+	for _, record := range records {
 		plugins.EnqueueLog(&plugins.Log{
-			Id:         uuid.New().String(),
+			Id:         record.ID,
 			TenantId:   utmTenantId,
 			DataType:   "o365",
 			DataSource: group.GroupName,
 			Timestamp:  time.Now().UTC().Format(time.RFC3339Nano),
-			Raw:        log,
-		}, "com.utmstack.o365")
+			Raw:        record.Raw,
+		}, pluginName)
 	}
+	return len(records), nil
 }
 
 type OfficeProcessor struct {
 	Credentials MicrosoftLoginResponse
-	// TenantId is the customer's own Microsoft Azure AD / Microsoft 365 tenant
-	// ID (config key "office365_tenant_id") — used to build Microsoft Graph
-	// API URLs. It is NOT UTMStack's platform tenant; see UtmTenantId.
+	// TenantId is the customer's Microsoft Azure AD tenant, used to build API
+	// URLs. It is NOT UTMStack's platform tenant; that is UtmTenantId.
 	TenantId         string
 	UtmTenantId      string
 	ClientId         string
@@ -345,7 +363,6 @@ func (o *OfficeProcessor) GetAuth() error {
 
 	dataBytes := []byte(data.Encode())
 
-	// Retry logic for authentication
 	maxRetries := 3
 	retryDelay := 2 * time.Second
 
@@ -360,19 +377,18 @@ func (o *OfficeProcessor) GetAuth() error {
 		}
 
 		_ = catcher.Error("error getting authentication, retrying", err, map[string]any{
-			"process":    "plugin_com.utmstack.o365",
+			"process":    processName,
 			"retry":      retry + 1,
 			"maxRetries": maxRetries,
 		})
 
 		if retry < maxRetries-1 {
 			time.Sleep(retryDelay)
-			// Increase delay for next retry
 			retryDelay *= 2
 		}
 	}
 
-	return catcher.Error("all retries failed when getting authentication", err, map[string]any{"process": "plugin_com.utmstack.o365"})
+	return catcher.Error("all retries failed when getting authentication", err, map[string]any{"process": processName})
 }
 
 func (o *OfficeProcessor) StartSubscriptions() error {
@@ -388,7 +404,6 @@ func (o *OfficeProcessor) StartSubscriptions() error {
 			"Authorization": fmt.Sprintf("%s %s", o.Credentials.TokenType, o.Credentials.AccessToken),
 		}
 
-		// Retry logic for starting subscriptions
 		maxRetries := 3
 		retryDelay := 2 * time.Second
 
@@ -400,13 +415,13 @@ func (o *OfficeProcessor) StartSubscriptions() error {
 				break
 			}
 
-			// If the subscription is already enabled, that's not an error
+			// Microsoft reports an already-enabled subscription as an error.
 			if strings.Contains(err.Error(), "subscription is already enabled") {
 				return nil
 			}
 
 			_ = catcher.Error("error starting subscription, retrying", err, map[string]any{
-				"process":      "plugin_com.utmstack.o365",
+				"process":      processName,
 				"retry":        retry + 1,
 				"maxRetries":   maxRetries,
 				"subscription": subscription,
@@ -414,14 +429,13 @@ func (o *OfficeProcessor) StartSubscriptions() error {
 
 			if retry < maxRetries-1 {
 				time.Sleep(retryDelay)
-				// Increase delay for next retry
 				retryDelay *= 2
 			}
 		}
 
 		if err != nil {
 			return catcher.Error("all retries failed when starting subscription", err, map[string]any{
-				"process":      "plugin_com.utmstack.o365",
+				"process":      processName,
 				"subscription": subscription,
 			})
 		}
@@ -445,7 +459,6 @@ func (o *OfficeProcessor) GetContentList(subscription string, startTime time.Tim
 		"Authorization": fmt.Sprintf("%s %s", o.Credentials.TokenType, o.Credentials.AccessToken),
 	}
 
-	// Retry logic for getting content list
 	maxRetries := 3
 	retryDelay := 2 * time.Second
 
@@ -460,7 +473,7 @@ func (o *OfficeProcessor) GetContentList(subscription string, startTime time.Tim
 		}
 
 		_ = catcher.Error("error getting content list, retrying", err, map[string]any{
-			"process":      "plugin_com.utmstack.o365",
+			"process":      processName,
 			"retry":        retry + 1,
 			"maxRetries":   maxRetries,
 			"subscription": subscription,
@@ -469,13 +482,12 @@ func (o *OfficeProcessor) GetContentList(subscription string, startTime time.Tim
 
 		if retry < maxRetries-1 {
 			time.Sleep(retryDelay)
-			// Increase delay for next retry
 			retryDelay *= 2
 		}
 	}
 
 	return []ContentList{}, catcher.Error("all retries failed when getting content list", err, map[string]any{
-		"process":      "plugin_com.utmstack.o365",
+		"process":      processName,
 		"subscription": subscription,
 		"status":       status,
 	})
@@ -487,7 +499,6 @@ func (o *OfficeProcessor) GetContentDetails(url string) (ContentDetailsResponse,
 		"Authorization": fmt.Sprintf("%s %s", o.Credentials.TokenType, o.Credentials.AccessToken),
 	}
 
-	// Retry logic for getting content details
 	maxRetries := 3
 	retryDelay := 2 * time.Second
 
@@ -502,7 +513,7 @@ func (o *OfficeProcessor) GetContentDetails(url string) (ContentDetailsResponse,
 		}
 
 		_ = catcher.Error("error getting content details, retrying", err, map[string]any{
-			"process":    "plugin_com.utmstack.o365",
+			"process":    processName,
 			"retry":      retry + 1,
 			"maxRetries": maxRetries,
 			"url":        url,
@@ -511,24 +522,26 @@ func (o *OfficeProcessor) GetContentDetails(url string) (ContentDetailsResponse,
 
 		if retry < maxRetries-1 {
 			time.Sleep(retryDelay)
-			// Increase delay for next retry
 			retryDelay *= 2
 		}
 	}
 
 	return ContentDetailsResponse{}, catcher.Error("all retries failed when getting content details", err, map[string]any{
-		"process": "plugin_com.utmstack.o365",
+		"process": processName,
 		"url":     url,
 		"status":  status,
 	})
 }
 
-func (o *OfficeProcessor) GetLogs(startTime, endTime time.Time) []string {
-	logs := make([]string, 0, 10)
+// GetLogs returns one LogRecord per audit detail. The Management Activity API
+// is two-step: list content blobs per subscription, then fetch each content URI.
+func (o *OfficeProcessor) GetLogs(startTime, endTime time.Time, group *ModuleGroup) []LogRecord {
+	records := make([]LogRecord, 0, 10)
+	groupKey := group.Key()
 	for _, subscription := range o.Subscriptions {
 		contentList, err := o.GetContentList(subscription, startTime, endTime)
 		if err != nil {
-			_ = catcher.Error("error getting content list", err, map[string]any{"process": "plugin_com.utmstack.o365"})
+			_ = catcher.Error("error getting content list", err, map[string]any{"process": processName})
 			continue
 		}
 
@@ -536,23 +549,27 @@ func (o *OfficeProcessor) GetLogs(startTime, endTime time.Time) []string {
 			for _, log := range contentList {
 				details, err := o.GetContentDetails(log.ContentUri)
 				if err != nil {
-					_ = catcher.Error("error getting content details", err, map[string]any{"process": "plugin_com.utmstack.o365"})
+					_ = catcher.Error("error getting content details", err, map[string]any{"process": processName})
 					continue
 				}
 				if len(details) > 0 {
 					for _, detail := range details {
 						rawDetail, err := json.Marshal(detail)
 						if err != nil {
-							_ = catcher.Error("error marshalling content details", err, map[string]any{"process": "plugin_com.utmstack.o365"})
+							_ = catcher.Error("error marshalling content details", err, map[string]any{"process": processName})
 							continue
 						}
-						logs = append(logs, string(rawDetail))
+						recordID, _ := detail["Id"].(string)
+						records = append(records, LogRecord{
+							ID:  eventIdentity(o.UtmTenantId, groupKey, log.ContentUri, recordID),
+							Raw: string(rawDetail),
+						})
 					}
 				}
 			}
 		}
 	}
-	return logs
+	return records
 }
 
 func ConnectionChecker(url string) error {
@@ -588,7 +605,7 @@ func checkConnection(url string, ctx context.Context) error {
 	defer func() {
 		err := resp.Body.Close()
 		if err != nil {
-			_ = catcher.Error("error closing response body: %v", err, map[string]any{"process": "plugin_com.utmstack.o365"})
+			_ = catcher.Error("error closing response body: %v", err, map[string]any{"process": processName})
 		}
 	}()
 
@@ -602,7 +619,7 @@ func infiniteRetryIfXError(f func() error, exception string) error {
 		err := f()
 		if err != nil && is(err, exception) {
 			if !xErrorWasLogged {
-				_ = catcher.Error("An error occurred (%s), will keep retrying indefinitely...", err, map[string]any{"process": "plugin_com.utmstack.o365"})
+				_ = catcher.Error("An error occurred (%s), will keep retrying indefinitely...", err, map[string]any{"process": processName})
 				xErrorWasLogged = true
 			}
 			time.Sleep(wait)

--- a/plugins/o365/queue.go
+++ b/plugins/o365/queue.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	"github.com/threatwinds/go-sdk/catcher"
+	"github.com/utmstack/UTMStack/plugins/shared/coordination"
+)
+
+const (
+	jobConsumedMsg       = "job consumed, cursor advanced"
+	coordinationReadyMsg = "coordination ready, consuming jobs"
+
+	// queuePlugin names the NATS stream, subjects, durable consumer and
+	// scheduler election key. Changing it orphans all of them on an existing
+	// deployment.
+	queuePlugin = "o365"
+)
+
+func logCoordinationReady() {
+	catcher.Info(coordinationReadyMsg, map[string]any{
+		"process":        processName,
+		"plugin":         queuePlugin,
+		"schedulerLease": coordination.SchedulerLeaseKey(queuePlugin),
+	})
+}
+
+// One job per group, never per tenant: a per-tenant job would collapse all of a
+// tenant's groups onto a single worker. Job.TenantID carries UtmTenantId, not
+// the Microsoft tenant id.
+func jobsForGroups(groups []*ModuleGroup, windowStart, windowEnd time.Time) []coordination.Job {
+	jobs := make([]coordination.Job, 0, len(groups))
+	for _, grp := range groups {
+		jobs = append(jobs, coordination.Job{
+			TenantID:    grp.UtmTenantId,
+			GroupName:   grp.GroupName,
+			WindowStart: windowStart,
+			WindowEnd:   windowEnd,
+		})
+	}
+	return jobs
+}
+
+func publishTickJobs(ctx context.Context, scheduler coordination.Store, publisher coordination.JobPublisher, holder string, groups []*ModuleGroup, windowStart, windowEnd time.Time) {
+	coordination.PublishJobsIfElected(ctx, scheduler, publisher,
+		coordination.SchedulerLeaseKey(queuePlugin), holder,
+		jobsForGroups(groups, windowStart, windowEnd),
+		func(job coordination.Job, err error) {
+			_ = catcher.Error("error publishing job", err, map[string]any{
+				"process": processName,
+				"group":   job.TenantID + "/" + job.GroupName,
+			})
+		})
+}
+
+// The key must match what group.Key() produces. Every worker loads the same
+// pipeline config, so a configured group resolves here too, modulo propagation lag.
+func resolveGroup(tenantId, groupName string) (*ModuleGroup, bool) {
+	activeGroupsMu.RLock()
+	defer activeGroupsMu.RUnlock()
+	grp, ok := activeGroups[tenantId+"/"+groupName]
+	return grp, ok
+}
+
+// Turns a delivered job into a pull() call and a persisted cursor. The
+// load-work-save-ack ordering belongs to coordination.ConsumeAndAdvanceCursor
+// and must not be hand-rolled here.
+func consumeJob(
+	ctx context.Context,
+	cursors coordination.CursorStore,
+	delivery coordination.JobDelivery,
+	group *ModuleGroup,
+	pullFn func(startTime, endTime time.Time, group *ModuleGroup) (int, error),
+	encryptionKey string,
+) error {
+	key := o365CursorKey(group)
+
+	// Captured by whichever callback runs, so the outcome can be logged only
+	// after the cursor is durable. ConsumeWork's signatures cannot return it.
+	var windowStart, windowEnd time.Time
+	var ingested int
+
+	work := coordination.ConsumeWork{
+		// First activation, no persisted cursor. job.WindowStart is seeded from
+		// "now minus one tick", never the epoch, so no full-history replay.
+		Activate: func(ctx context.Context, job coordination.Job) ([]byte, error) {
+			now := time.Now().UTC()
+			n, err := pullFn(job.WindowStart, now, group)
+			if err != nil {
+				return nil, err
+			}
+			windowStart, windowEnd, ingested = job.WindowStart, now, n
+			return coordination.MarshalCursorPayload(cursorPayload{WindowEnd: now}, encryptionKey)
+		},
+		// The starting point is cur.Data, never job.WindowStart: a different
+		// worker may have handled the previous tick.
+		Resume: func(ctx context.Context, job coordination.Job, cur coordination.Cursor) ([]byte, error) {
+			prev, err := coordination.UnmarshalCursorPayload[cursorPayload](cur.Data, encryptionKey)
+			if err != nil {
+				return nil, err
+			}
+			now := time.Now().UTC()
+			n, err := pullFn(prev.WindowEnd, now, group)
+			if err != nil {
+				return nil, err
+			}
+			windowStart, windowEnd, ingested = prev.WindowEnd, now, n
+			return coordination.MarshalCursorPayload(cursorPayload{WindowEnd: now}, encryptionKey)
+		},
+	}
+
+	if err := coordination.ConsumeAndAdvanceCursor(ctx, cursors, delivery, key, work); err != nil {
+		return err
+	}
+
+	catcher.Info(jobConsumedMsg, map[string]any{
+		"process":     processName,
+		"group":       group.Key(),
+		"windowStart": windowStart.Format(time.RFC3339Nano),
+		"windowEnd":   windowEnd.Format(time.RFC3339Nano),
+		"records":     ingested,
+	})
+	return nil
+}
+
+// Durable consumer goroutine; start once per process.
+func runQueueConsumer(ctx context.Context, consumer coordination.JobConsumer, cursors coordination.CursorStore, encryptionKeyFn func() string) {
+	coordination.RunJobConsumer(ctx, consumer,
+		func(ctx context.Context, delivery coordination.JobDelivery) error {
+			group, ok := resolveGroup(delivery.Job.TenantID, delivery.Job.GroupName)
+			if !ok {
+				// Group not configured on this worker. Deliberately neither
+				// acked nor nacked: AckWait drives redelivery, and MaxDeliver
+				// exhaustion drops the job if the group is gone everywhere.
+				return nil
+			}
+			return consumeJob(ctx, cursors, delivery, group, pull, encryptionKeyFn())
+		},
+		func(err error) {
+			_ = catcher.Error("error consuming job", err, map[string]any{"process": processName})
+		})
+}

--- a/plugins/shared/coordination/acquire.go
+++ b/plugins/shared/coordination/acquire.go
@@ -1,0 +1,39 @@
+package coordination
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// No error ends the loop: giving up would leave the unit ingested by nobody.
+// ErrHeld never reaches onError; a contended key is the expected steady state.
+func AcquireWithRetry(
+	ctx context.Context, store Store,
+	key, holder string,
+	ttl, retryInterval time.Duration,
+	onError func(error),
+) (Lease, error) {
+	for {
+		if err := ctx.Err(); err != nil {
+			return Lease{}, err
+		}
+
+		lease, err := store.Acquire(ctx, key, holder, ttl)
+		if err == nil {
+			return lease, nil
+		}
+
+		// A Store propagating ctx fails with the context's error, not ErrHeld.
+		if onError != nil && !errors.Is(err, ErrHeld) && ctx.Err() == nil {
+			onError(err)
+		}
+
+		select {
+		case <-ctx.Done():
+			// Zero Lease: nothing the caller could mistake for ownership.
+			return Lease{}, ctx.Err()
+		case <-time.After(retryInterval):
+		}
+	}
+}

--- a/plugins/shared/coordination/clock.go
+++ b/plugins/shared/coordination/clock.go
@@ -1,0 +1,7 @@
+package coordination
+
+import "time"
+
+type RealClock struct{}
+
+func (RealClock) Now() time.Time { return time.Now() }

--- a/plugins/shared/coordination/consume.go
+++ b/plugins/shared/coordination/consume.go
@@ -1,0 +1,68 @@
+package coordination
+
+import (
+	"context"
+	"errors"
+)
+
+type ConsumeWork struct {
+	Resume func(ctx context.Context, job Job, cur Cursor) (next []byte, err error)
+
+	// Called instead of Resume on first activation. The position it returns
+	// must be seeded from "now", or the source's history is replayed whole.
+	Activate func(ctx context.Context, job Job) (next []byte, err error)
+}
+
+var ErrMissingActivateWork = errors.New("coordination: ConsumeAndAdvanceCursor: first activation occurred but ConsumeWork.Activate is nil")
+
+var ErrMissingResumeWork = errors.New("coordination: ConsumeAndAdvanceCursor: a cursor already exists for this key but ConsumeWork.Resume is nil")
+
+// Nothing is Acked on failure, so AckWait drives redelivery. On
+// ErrCursorConflict the write is dropped but the job is Acked anyway: the work
+// already published.
+func ConsumeAndAdvanceCursor(
+	ctx context.Context,
+	cursors CursorStore,
+	delivery JobDelivery,
+	cursorKey string,
+	work ConsumeWork,
+) error {
+	cur, loadErr := cursors.Load(ctx, cursorKey)
+
+	var next []byte
+	var workErr error
+
+	switch {
+	case loadErr == nil:
+		if work.Resume == nil {
+			return ErrMissingResumeWork
+		}
+		next, workErr = work.Resume(ctx, delivery.Job, cur)
+
+	case errors.Is(loadErr, ErrCursorNotFound):
+		if work.Activate == nil {
+			return ErrMissingActivateWork
+		}
+		next, workErr = work.Activate(ctx, delivery.Job)
+
+	default:
+		// Load failed for a reason other than "no cursor yet".
+		return loadErr
+	}
+
+	if workErr != nil {
+		// No Save and no Ack: the next attempt re-pulls the same window.
+		return workErr
+	}
+
+	if _, saveErr := cursors.Save(ctx, cursorKey, Cursor{Data: next, Revision: cur.Revision}); saveErr != nil {
+		if errors.Is(saveErr, ErrCursorConflict) {
+			// CAS loser: discard this write, but still Ack.
+			return delivery.Ack()
+		}
+		// Genuine Save failure: do not Ack, let AckWait retry.
+		return saveErr
+	}
+
+	return delivery.Ack()
+}

--- a/plugins/shared/coordination/consumer_loop.go
+++ b/plugins/shared/coordination/consumer_loop.go
@@ -1,0 +1,41 @@
+package coordination
+
+import (
+	"context"
+	"errors"
+)
+
+// No error ends the loop: one group's transient failure must not stop
+// ingestion for the rest. ErrNoJobs and cancellation never reach onError.
+func RunJobConsumer(
+	ctx context.Context,
+	consumer JobConsumer,
+	handle func(ctx context.Context, delivery JobDelivery) error,
+	onError func(err error),
+) {
+	for {
+		// Checked here and again below before ErrNoJobs: Fetch reports a
+		// cancelled context as ErrNoJobs, so testing that first would spin.
+		if ctx.Err() != nil {
+			return
+		}
+
+		delivery, err := consumer.Fetch(ctx)
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			if errors.Is(err, ErrNoJobs) {
+				continue
+			}
+			if onError != nil {
+				onError(err)
+			}
+			continue
+		}
+
+		if err := handle(ctx, delivery); err != nil && onError != nil {
+			onError(err)
+		}
+	}
+}

--- a/plugins/shared/coordination/cursor.go
+++ b/plugins/shared/coordination/cursor.go
@@ -1,0 +1,29 @@
+package coordination
+
+import (
+	"context"
+	"errors"
+)
+
+type Cursor struct {
+	Data []byte
+	// CAS token in CursorStore, unrelated to Lease.Revision.
+	Revision uint64
+}
+
+// Callers must treat this as "seed from now", never "seed from epoch".
+var ErrCursorNotFound = errors.New("cursor: key has no persisted value yet")
+
+var ErrCursorConflict = errors.New("cursor: revision stale, another writer saved since Load")
+
+// Save exceeded the transport's max message payload: 1,048,576 bytes on the
+// deployed nats:2.10-alpine v2.10.29 server. It will fail identically on retry.
+var ErrCursorTooLarge = errors.New("cursor: payload exceeds the transport's maximum message size")
+
+type CursorStore interface {
+	Load(ctx context.Context, key string) (Cursor, error)
+
+	// CAS write. c.Revision == 0 means "create" and fails if key exists; any
+	// other value means "update only if still current".
+	Save(ctx context.Context, key string, c Cursor) (Cursor, error)
+}

--- a/plugins/shared/coordination/cursor_payload.go
+++ b/plugins/shared/coordination/cursor_payload.go
@@ -1,0 +1,46 @@
+package coordination
+
+import (
+	"encoding/json"
+
+	"github.com/utmstack/UTMStack/plugins/shared/crypto"
+)
+
+// NATS has neither auth nor TLS here. Jobs stay unencrypted: their subject
+// already carries tenant and group for routing.
+func MarshalCursorPayload(v any, encryptionKey string) ([]byte, error) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	if encryptionKey == "" {
+		return data, nil
+	}
+
+	encrypted, err := crypto.NewCipher(encryptionKey).Encrypt(string(data))
+	if err != nil {
+		return nil, err
+	}
+	return []byte(encrypted), nil
+}
+
+// Cursors written before a key was configured stay readable: Decrypt passes
+// already-plaintext input through unchanged.
+func UnmarshalCursorPayload[T any](data []byte, encryptionKey string) (T, error) {
+	var zero T
+
+	raw := data
+	if encryptionKey != "" {
+		decrypted, err := crypto.NewCipher(encryptionKey).Decrypt(string(data))
+		if err != nil {
+			return zero, err
+		}
+		raw = []byte(decrypted)
+	}
+
+	var out T
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return zero, err
+	}
+	return out, nil
+}

--- a/plugins/shared/coordination/dial.go
+++ b/plugins/shared/coordination/dial.go
@@ -1,0 +1,36 @@
+package coordination
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// ConnectJetStream dials NATS_URL. The caller owns the returned *nats.Conn and
+// must Close it. connName identifies this plugin to the server.
+func ConnectJetStream(ctx context.Context, connName string) (jetstream.JetStream, *nats.Conn, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
+
+	url := os.Getenv("NATS_URL")
+	if url == "" {
+		return nil, nil, fmt.Errorf("NATS_URL is required")
+	}
+
+	nc, err := nats.Connect(url, nats.MaxReconnects(-1), nats.Name(connName))
+	if err != nil {
+		return nil, nil, fmt.Errorf("connecting to NATS: %w", err)
+	}
+
+	js, err := jetstream.New(nc)
+	if err != nil {
+		nc.Close()
+		return nil, nil, fmt.Errorf("creating the JetStream context: %w", err)
+	}
+
+	return js, nc, nil
+}

--- a/plugins/shared/coordination/heartbeat.go
+++ b/plugins/shared/coordination/heartbeat.go
@@ -1,0 +1,87 @@
+package coordination
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// Must stay defined as bucketTTL: that is the TTL the server enforces.
+const LeaseTTL = bucketTTL
+
+const HeartbeatInterval = LeaseTTL / 3
+
+const AcquireRetryInterval = HeartbeatInterval
+
+// Must read the caller's live position; a captured payload never advances.
+type CursorSnapshot func() ([]byte, error)
+
+type Heartbeat struct {
+	Leases  Store
+	Cursors CursorStore
+
+	// One key for both lease and cursor, so a successor finds the position.
+	Key string
+
+	Snapshot CursorSnapshot
+
+	TTL time.Duration
+
+	Interval time.Duration
+
+	// Must be the same CancelFunc that stops the unit for any other reason:
+	// refusing new work leaves a feed socket held open for hours.
+	Cancel context.CancelFunc
+
+	OnError func(error)
+}
+
+// The caller carries the returned lease and revision into the next tick. On
+// ErrFenced both are zero and the unit must stop; otherwise the lease is held.
+func (h Heartbeat) Tick(ctx context.Context, lease Lease, cursorRev uint64) (Lease, uint64, error) {
+	data, err := h.Snapshot()
+	if err != nil {
+		// Lease returned unchanged: a snapshot failure is a payload bug.
+		return lease, cursorRev, err
+	}
+
+	renewed, saved, err := RenewAndPersistCursor(ctx, h.Leases, h.Cursors, lease, h.TTL, h.Key, data, cursorRev)
+	if err != nil {
+		if errors.Is(err, ErrFenced) {
+			// Verbatim: wrapping disables the only signal that stops the unit.
+			return Lease{}, 0, err
+		}
+		return renewed, cursorRev, err
+	}
+
+	return renewed, saved.Revision, nil
+}
+
+func (h Heartbeat) Run(ctx context.Context, lease Lease, cursorRev uint64) {
+	ticker := time.NewTicker(h.Interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+
+		nextLease, nextRev, err := h.Tick(ctx, lease, cursorRev)
+		if err != nil {
+			if h.OnError != nil {
+				h.OnError(err)
+			}
+			if errors.Is(err, ErrFenced) {
+				if h.Cancel != nil {
+					h.Cancel()
+				}
+				return
+			}
+		}
+
+		lease = nextLease
+		cursorRev = nextRev
+	}
+}

--- a/plugins/shared/coordination/lease_path.go
+++ b/plugins/shared/coordination/lease_path.go
@@ -1,0 +1,76 @@
+package coordination
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+type NATSCloser interface {
+	Close()
+}
+
+type LeasePath struct {
+	Leases  Store
+	Cursors CursorStore
+
+	// Only non-nil on a successful setup.
+	Close func()
+}
+
+type LeasePathBuild struct {
+	Connect        func(ctx context.Context) (jetstream.JetStream, NATSCloser, error)
+	NewLeaseStore  func(ctx context.Context, js jetstream.JetStream, clock Clock) (Store, error)
+	NewCursorStore func(ctx context.Context, js jetstream.JetStream) (CursorStore, error)
+}
+
+func DefaultLeasePathBuild(connName string) LeasePathBuild {
+	return LeasePathBuild{
+		Connect: func(ctx context.Context) (jetstream.JetStream, NATSCloser, error) {
+			js, nc, err := ConnectJetStream(ctx, connName)
+			if err != nil {
+				// Untyped nil, not the nil *nats.Conn: a nil pointer boxed in
+				// a non-nil interface passes `closer != nil`, then panics.
+				return nil, nil, err
+			}
+			return js, nc, nil
+		},
+		NewLeaseStore: func(ctx context.Context, js jetstream.JetStream, clock Clock) (Store, error) {
+			return NewNATSStore(ctx, js, clock)
+		},
+		NewCursorStore: func(ctx context.Context, js jetstream.JetStream) (CursorStore, error) {
+			return NewNATSCursorStore(ctx, js)
+		},
+	}
+}
+
+// Atomic. Callers retry forever, so a connection left open on a late failure
+// would leak one per attempt, and a partial LeasePath would ingest unowned.
+func SetupLeasePath(ctx context.Context, b LeasePathBuild) (LeasePath, error) {
+	js, nc, err := b.Connect(ctx)
+	if err != nil {
+		return LeasePath{}, fmt.Errorf("connecting to NATS JetStream: %w", err)
+	}
+
+	leases, err := b.NewLeaseStore(ctx, js, RealClock{})
+	if err != nil {
+		nc.Close()
+		return LeasePath{}, fmt.Errorf("creating the lease store: %w", err)
+	}
+
+	cursors, err := b.NewCursorStore(ctx, js)
+	if err != nil {
+		nc.Close()
+		return LeasePath{}, fmt.Errorf("creating the cursor store: %w", err)
+	}
+
+	return LeasePath{Leases: leases, Cursors: cursors, Close: nc.Close}, nil
+}
+
+func DialLeasePath(connName string) func(ctx context.Context) (LeasePath, error) {
+	build := DefaultLeasePathBuild(connName)
+	return func(ctx context.Context) (LeasePath, error) {
+		return SetupLeasePath(ctx, build)
+	}
+}

--- a/plugins/shared/coordination/lease_store.go
+++ b/plugins/shared/coordination/lease_store.go
@@ -1,0 +1,117 @@
+package coordination
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+const (
+	// LeaseBucketName is exported so plugins can name the bucket in their logs
+	// without keeping a copy of the string.
+	// Keys are prefixed with the plugin name, e.g. "aws.<tenantId>/<group>".
+	LeaseBucketName = "ingest_leases"
+
+	// Bucket-level, not per key: per-key TTL requires NATS 2.11+ and the
+	// deployed server is nats:2.10-alpine.
+	bucketTTL = 45 * time.Second
+
+	bucketHistory = 1
+
+	// Separate bucket: one bucket cannot hold both TTLs.
+	schedulerBucketName = "ingest_scheduler"
+
+	schedulerBucketTTL = 20 * time.Second
+)
+
+type leaseValue struct {
+	Holder     string    `json:"holder"`
+	AcquiredAt time.Time `json:"acquiredAt"`
+}
+
+type NATSStore struct {
+	kv    jetstream.KeyValue
+	clock Clock
+}
+
+func NewNATSStore(ctx context.Context, js jetstream.JetStream, clock Clock) (*NATSStore, error) {
+	return NewNATSStoreWithBucket(ctx, js, clock, LeaseBucketName, bucketTTL)
+}
+
+func NewNATSSchedulerStore(ctx context.Context, js jetstream.JetStream, clock Clock) (*NATSStore, error) {
+	return NewNATSStoreWithBucket(ctx, js, clock, schedulerBucketName, schedulerBucketTTL)
+}
+
+// Expiry on NATS is a property of the bucket, not the clock, so a caller
+// needing a different TTL needs a different bucket.
+func NewNATSStoreWithBucket(ctx context.Context, js jetstream.JetStream, clock Clock, bucket string, ttl time.Duration) (*NATSStore, error) {
+	kv, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
+		Bucket:  bucket,
+		TTL:     ttl,
+		History: bucketHistory,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &NATSStore{kv: kv, clock: clock}, nil
+}
+
+func (s *NATSStore) Acquire(ctx context.Context, key, holder string, ttl time.Duration) (Lease, error) {
+	acquiredAt := s.clock.Now()
+	data, err := json.Marshal(leaseValue{Holder: holder, AcquiredAt: acquiredAt})
+	if err != nil {
+		return Lease{}, err
+	}
+
+	revision, err := s.kv.Create(ctx, key, data)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrKeyExists) {
+			return Lease{}, ErrHeld
+		}
+		return Lease{}, err
+	}
+
+	return Lease{
+		Key:       key,
+		Holder:    holder,
+		Revision:  revision,
+		ExpiresAt: acquiredAt.Add(ttl),
+	}, nil
+}
+
+func (s *NATSStore) Renew(ctx context.Context, l Lease, ttl time.Duration) (Lease, error) {
+	renewedAt := s.clock.Now()
+	data, err := json.Marshal(leaseValue{Holder: l.Holder, AcquiredAt: renewedAt})
+	if err != nil {
+		return Lease{}, err
+	}
+
+	revision, err := s.kv.Update(ctx, l.Key, data, l.Revision)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
+			return Lease{}, ErrFenced
+		}
+		return Lease{}, err
+	}
+
+	return Lease{
+		Key:       l.Key,
+		Holder:    l.Holder,
+		Revision:  revision,
+		ExpiresAt: renewedAt.Add(ttl),
+	}, nil
+}
+
+// Revision-guarded on purpose: unguarded, a holder that froze past its TTL and
+// then called Release would delete the lease a successor had already won.
+func (s *NATSStore) Release(ctx context.Context, l Lease) error {
+	err := s.kv.Delete(ctx, l.Key, jetstream.LastRevision(l.Revision))
+	if errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
+		return ErrFenced
+	}
+	return err
+}

--- a/plugins/shared/coordination/load_cursor.go
+++ b/plugins/shared/coordination/load_cursor.go
@@ -1,0 +1,27 @@
+package coordination
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// An absent cursor returns found=false, no error, dst untouched: callers must
+// treat that as "seed from now". A decode failure still returns the stored
+// revision, or the next Save means "create" on a live key and fails forever.
+func LoadCursorInto[T any](ctx context.Context, cursors CursorStore, key string, dst *T) (uint64, bool, error) {
+	cur, err := cursors.Load(ctx, key)
+	if err != nil {
+		if errors.Is(err, ErrCursorNotFound) {
+			return 0, false, nil
+		}
+		return 0, false, err
+	}
+
+	if err := json.Unmarshal(cur.Data, dst); err != nil {
+		return cur.Revision, false, fmt.Errorf("decoding the persisted cursor for %q: %w", key, err)
+	}
+
+	return cur.Revision, true, nil
+}

--- a/plugins/shared/coordination/nats_cursor_store.go
+++ b/plugins/shared/coordination/nats_cursor_store.go
@@ -1,0 +1,77 @@
+package coordination
+
+import (
+	"context"
+	"errors"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+const (
+	// CursorBucketName is exported so plugins can name the bucket in their logs
+	// without keeping a copy of the string.
+	CursorBucketName = "ingest_cursors"
+
+	cursorBucketHistory = 1
+)
+
+// Backed by a bucket with no TTL. The lease bucket expires by deleting its
+// keys, and position must survive exactly that moment.
+type NATSCursorStore struct {
+	kv jetstream.KeyValue
+}
+
+func NewNATSCursorStore(ctx context.Context, js jetstream.JetStream) (*NATSCursorStore, error) {
+	kv, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
+		Bucket:  CursorBucketName,
+		History: cursorBucketHistory,
+		// TTL omitted: keys in this bucket must never expire.
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &NATSCursorStore{kv: kv}, nil
+}
+
+func (s *NATSCursorStore) Load(ctx context.Context, key string) (Cursor, error) {
+	entry, err := s.kv.Get(ctx, key)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrKeyNotFound) {
+			return Cursor{}, ErrCursorNotFound
+		}
+		return Cursor{}, err
+	}
+
+	return Cursor{Data: entry.Value(), Revision: entry.Revision()}, nil
+}
+
+func (s *NATSCursorStore) Save(ctx context.Context, key string, c Cursor) (Cursor, error) {
+	if c.Revision == 0 {
+		revision, err := s.kv.Create(ctx, key, c.Data)
+		if err != nil {
+			if errors.Is(err, jetstream.ErrKeyExists) {
+				return Cursor{}, ErrCursorConflict
+			}
+			return Cursor{}, translateSaveErr(err)
+		}
+		return Cursor{Data: c.Data, Revision: revision}, nil
+	}
+
+	revision, err := s.kv.Update(ctx, key, c.Data, c.Revision)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrKeyRevisionMismatch) {
+			return Cursor{}, ErrCursorConflict
+		}
+		return Cursor{}, translateSaveErr(err)
+	}
+	return Cursor{Data: c.Data, Revision: revision}, nil
+}
+
+func translateSaveErr(err error) error {
+	if errors.Is(err, nats.ErrMaxPayload) {
+		return ErrCursorTooLarge
+	}
+	return err
+}

--- a/plugins/shared/coordination/nats_queue.go
+++ b/plugins/shared/coordination/nats_queue.go
@@ -1,0 +1,146 @@
+package coordination
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+const (
+	// A job is only a hint; CursorStore holds the authoritative position.
+	jobStreamMaxAge = 1 * time.Hour
+
+	// Long enough that a real pull against a third-party API is not read as a
+	// dead worker.
+	jobConsumerAckWait = 4*time.Minute + 30*time.Second
+
+	jobConsumerMaxDeliver = 3
+
+	jobConsumerDurableSuffix = "-workers"
+
+	jobSubjectPrefix = "jobs"
+)
+
+func jobStreamName(plugin string) string {
+	return "INGEST_JOBS_" + strings.ToUpper(plugin)
+}
+
+func jobSubject(plugin string, job Job) string {
+	return fmt.Sprintf("%s.%s.%s.%s", jobSubjectPrefix, plugin, job.TenantID, job.GroupName)
+}
+
+func jobSubjectFilter(plugin string) string {
+	return fmt.Sprintf("%s.%s.>", jobSubjectPrefix, plugin)
+}
+
+// Called by both constructors, so a worker may start before any scheduler.
+func ensureJobStream(ctx context.Context, js jetstream.JetStream, plugin string) error {
+	_, err := js.CreateOrUpdateStream(ctx, jetstream.StreamConfig{
+		Name:      jobStreamName(plugin),
+		Subjects:  []string{jobSubjectFilter(plugin)},
+		Retention: jetstream.WorkQueuePolicy,
+		MaxAge:    jobStreamMaxAge,
+	})
+	return err
+}
+
+type NATSJobPublisher struct {
+	js     jetstream.JetStream
+	plugin string
+}
+
+func NewNATSJobPublisher(ctx context.Context, js jetstream.JetStream, plugin string) (*NATSJobPublisher, error) {
+	if err := ensureJobStream(ctx, js, plugin); err != nil {
+		return nil, err
+	}
+	return &NATSJobPublisher{js: js, plugin: plugin}, nil
+}
+
+func (p *NATSJobPublisher) Publish(ctx context.Context, job Job) error {
+	data, err := json.Marshal(job)
+	if err != nil {
+		return err
+	}
+
+	_, err = p.js.Publish(ctx, jobSubject(p.plugin, job), data)
+	return err
+}
+
+type NATSJobConsumer struct {
+	consumer jetstream.Consumer
+}
+
+func NewNATSJobConsumer(ctx context.Context, js jetstream.JetStream, plugin string) (*NATSJobConsumer, error) {
+	return NewNATSJobConsumerWithConfig(ctx, js, plugin, jobConsumerAckWait, jobConsumerMaxDeliver)
+}
+
+func NewNATSJobConsumerWithConfig(ctx context.Context, js jetstream.JetStream, plugin string, ackWait time.Duration, maxDeliver int) (*NATSJobConsumer, error) {
+	if err := ensureJobStream(ctx, js, plugin); err != nil {
+		return nil, err
+	}
+
+	consumer, err := js.CreateOrUpdateConsumer(ctx, jobStreamName(plugin), jetstream.ConsumerConfig{
+		Durable:       plugin + jobConsumerDurableSuffix,
+		AckPolicy:     jetstream.AckExplicitPolicy,
+		AckWait:       ackWait,
+		MaxDeliver:    maxDeliver,
+		FilterSubject: jobSubjectFilter(plugin),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &NATSJobConsumer{consumer: consumer}, nil
+}
+
+// JetStream has no idle signal: Next returns nats.ErrTimeout for an empty
+// fetch, the same error a broken connection produces.
+func isEmptyFetchWindow(ctx context.Context, err error) bool {
+	// Which spelling arrives depends on the server version and on whether the
+	// request expired server-side or returned an empty batch.
+	if errors.Is(err, nats.ErrTimeout) || errors.Is(err, jetstream.ErrNoMessages) {
+		return true
+	}
+
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+
+	// A ctx already done on entry never reaches the server: FetchContext
+	// rejects it with ErrInvalidOption, carrying neither context sentinel.
+	return ctx.Err() != nil && errors.Is(err, jetstream.ErrInvalidOption)
+}
+
+func (c *NATSJobConsumer) Fetch(ctx context.Context) (JobDelivery, error) {
+	msg, err := c.consumer.Next(jetstream.FetchContext(ctx))
+	if err != nil {
+		if isEmptyFetchWindow(ctx, err) {
+			// Wrapped, so the transport's own cause stays unwrappable.
+			return JobDelivery{}, fmt.Errorf("%w: %w", ErrNoJobs, err)
+		}
+		return JobDelivery{}, err
+	}
+
+	var job Job
+	if err := json.Unmarshal(msg.Data(), &job); err != nil {
+		return JobDelivery{}, err
+	}
+
+	meta, err := msg.Metadata()
+	if err != nil {
+		return JobDelivery{}, err
+	}
+
+	return JobDelivery{
+		Job:          job,
+		NumDelivered: meta.NumDelivered,
+		Ack:          msg.Ack,
+		Nak:          msg.Nak,
+	}, nil
+}

--- a/plugins/shared/coordination/queue.go
+++ b/plugins/shared/coordination/queue.go
@@ -1,0 +1,44 @@
+package coordination
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// WindowStart and WindowEnd are a hint only: the consumer's authoritative
+// position is CursorStore.Load, so they matter only on a first activation.
+type Job struct {
+	TenantID    string    `json:"tenantId"`
+	GroupName   string    `json:"groupName"`
+	WindowStart time.Time `json:"windowStart"`
+	WindowEnd   time.Time `json:"windowEnd"`
+}
+
+type JobPublisher interface {
+	Publish(ctx context.Context, job Job) error
+}
+
+// Exactly one of Ack or Nak must eventually be called.
+type JobDelivery struct {
+	Job Job
+
+	// 1 on first delivery, incremented on every redelivery.
+	NumDelivered uint64
+
+	Ack func() error
+
+	// Requests immediate redelivery rather than waiting out AckWait.
+	Nak func() error
+}
+
+// A job exceeding MaxDeliver is dropped by JetStream with no signal and no
+// dead-letter subject. No DLQ is needed: a failed job never advanced the
+// cursor, so the next tick republishes the group and retries the same window.
+type JobConsumer interface {
+	Fetch(ctx context.Context) (JobDelivery, error)
+}
+
+// A normal idle result, never a failure. JetStream reports an expired pull with
+// nats.ErrTimeout, the same error a network partition produces.
+var ErrNoJobs = errors.New("queue: no job available within the fetch window")

--- a/plugins/shared/coordination/queue_path.go
+++ b/plugins/shared/coordination/queue_path.go
@@ -1,0 +1,100 @@
+package coordination
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+type QueuePath struct {
+	Scheduler Store
+	Publisher JobPublisher
+	Consumer  JobConsumer
+	Cursors   CursorStore
+
+	// Only non-nil on a successful setup.
+	Close func()
+}
+
+type QueuePathBuild struct {
+	Connect           func(ctx context.Context) (jetstream.JetStream, NATSCloser, error)
+	NewSchedulerStore func(ctx context.Context, js jetstream.JetStream, clock Clock) (Store, error)
+	NewJobPublisher   func(ctx context.Context, js jetstream.JetStream) (JobPublisher, error)
+	NewJobConsumer    func(ctx context.Context, js jetstream.JetStream) (JobConsumer, error)
+	NewCursorStore    func(ctx context.Context, js jetstream.JetStream) (CursorStore, error)
+}
+
+func DefaultQueuePathBuild(connName, plugin string) QueuePathBuild {
+	return QueuePathBuild{
+		Connect: func(ctx context.Context) (jetstream.JetStream, NATSCloser, error) {
+			js, nc, err := ConnectJetStream(ctx, connName)
+			if err != nil {
+				// Untyped nil, not the nil *nats.Conn: a nil pointer boxed
+				// in a non-nil interface passes `closer != nil`, then panics.
+				return nil, nil, err
+			}
+			return js, nc, nil
+		},
+		NewSchedulerStore: func(ctx context.Context, js jetstream.JetStream, clock Clock) (Store, error) {
+			return NewNATSSchedulerStore(ctx, js, clock)
+		},
+		NewJobPublisher: func(ctx context.Context, js jetstream.JetStream) (JobPublisher, error) {
+			return NewNATSJobPublisher(ctx, js, plugin)
+		},
+		NewJobConsumer: func(ctx context.Context, js jetstream.JetStream) (JobConsumer, error) {
+			return NewNATSJobConsumer(ctx, js, plugin)
+		},
+		NewCursorStore: func(ctx context.Context, js jetstream.JetStream) (CursorStore, error) {
+			return NewNATSCursorStore(ctx, js)
+		},
+	}
+}
+
+// Atomic. Callers retry forever, so a connection left open on a late failure
+// would leak one per attempt, and a partial QueuePath would skip the election.
+func SetupQueuePath(ctx context.Context, b QueuePathBuild) (QueuePath, error) {
+	js, nc, err := b.Connect(ctx)
+	if err != nil {
+		return QueuePath{}, fmt.Errorf("connecting to NATS JetStream: %w", err)
+	}
+
+	scheduler, err := b.NewSchedulerStore(ctx, js, RealClock{})
+	if err != nil {
+		nc.Close()
+		return QueuePath{}, fmt.Errorf("creating the scheduler store: %w", err)
+	}
+
+	publisher, err := b.NewJobPublisher(ctx, js)
+	if err != nil {
+		nc.Close()
+		return QueuePath{}, fmt.Errorf("creating the job publisher: %w", err)
+	}
+
+	consumer, err := b.NewJobConsumer(ctx, js)
+	if err != nil {
+		nc.Close()
+		return QueuePath{}, fmt.Errorf("creating the job consumer: %w", err)
+	}
+
+	cursors, err := b.NewCursorStore(ctx, js)
+	if err != nil {
+		nc.Close()
+		return QueuePath{}, fmt.Errorf("creating the cursor store: %w", err)
+	}
+
+	return QueuePath{
+		Scheduler: scheduler,
+		Publisher: publisher,
+		Consumer:  consumer,
+		Cursors:   cursors,
+		Close:     nc.Close,
+	}, nil
+}
+
+func DialQueuePath(connName, plugin string) func(ctx context.Context) (QueuePath, error) {
+	build := DefaultQueuePathBuild(connName, plugin)
+	return func(ctx context.Context) (QueuePath, error) {
+		return SetupQueuePath(ctx, build)
+	}
+}

--- a/plugins/shared/coordination/renew.go
+++ b/plugins/shared/coordination/renew.go
@@ -1,0 +1,28 @@
+package coordination
+
+import (
+	"context"
+	"time"
+)
+
+// The only sanctioned lease-path cursor write: Renew first, Save only if it
+// succeeded, so a holder whose lease was taken over cannot reach Save.
+func RenewAndPersistCursor(
+	ctx context.Context, store Store, cursors CursorStore,
+	l Lease, ttl time.Duration,
+	cursorKey string, cursorData []byte, cursorRev uint64,
+) (Lease, Cursor, error) {
+	renewed, err := store.Renew(ctx, l, ttl)
+	if err != nil {
+		// ErrFenced short-circuits here, before Save.
+		return Lease{}, Cursor{}, err
+	}
+
+	saved, err := cursors.Save(ctx, cursorKey, Cursor{Data: cursorData, Revision: cursorRev})
+	if err != nil {
+		// The returned lease is still held; only this snapshot was lost.
+		return renewed, Cursor{}, err
+	}
+
+	return renewed, saved, nil
+}

--- a/plugins/shared/coordination/retry.go
+++ b/plugins/shared/coordination/retry.go
@@ -1,0 +1,29 @@
+package coordination
+
+import (
+	"context"
+	"time"
+)
+
+// Must never fall back to proceeding without a successful dial.
+// nats.MaxReconnects(-1) only protects an already-established connection, and
+// `docker stack deploy` ignores depends_on, so NATS may be down at startup.
+func SetupWithRetry[T any](ctx context.Context, dial func(ctx context.Context) (T, error), retryDelay time.Duration, onFailure func(err error)) (T, error) {
+	for {
+		v, err := dial(ctx)
+		if err == nil {
+			return v, nil
+		}
+
+		if onFailure != nil {
+			onFailure(err)
+		}
+
+		select {
+		case <-ctx.Done():
+			var zero T
+			return zero, ctx.Err()
+		case <-time.After(retryDelay):
+		}
+	}
+}

--- a/plugins/shared/coordination/scheduler.go
+++ b/plugins/shared/coordination/scheduler.go
@@ -1,0 +1,34 @@
+package coordination
+
+import "context"
+
+// Only covers one tick's publish; it expires before the next, unrenewed.
+const SchedulerLeaseTTL = schedulerBucketTTL
+
+// The plugin namespace is load-bearing: every queue-path plugin shares one
+// bucket, so an unnamespaced key would elect one publisher across all of them.
+func SchedulerLeaseKey(plugin string) string {
+	return "scheduler." + plugin
+}
+
+// Any acquire failure is a silent no-op; a second publisher would only
+// duplicate jobs. A Publish failure must not abort the rest of the tick.
+func PublishJobsIfElected(
+	ctx context.Context,
+	scheduler Store,
+	publisher JobPublisher,
+	leaseKey string,
+	holder string,
+	jobs []Job,
+	onError func(job Job, err error),
+) {
+	if _, err := scheduler.Acquire(ctx, leaseKey, holder, SchedulerLeaseTTL); err != nil {
+		return
+	}
+
+	for _, job := range jobs {
+		if err := publisher.Publish(ctx, job); err != nil && onError != nil {
+			onError(job, err)
+		}
+	}
+}

--- a/plugins/shared/coordination/store.go
+++ b/plugins/shared/coordination/store.go
@@ -1,0 +1,39 @@
+// Package coordination distributes ingestion work across worker processes.
+package coordination
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+type Clock interface {
+	Now() time.Time
+}
+
+// No position field: this bucket's TTL deletes the key, and failover happens by
+// that expiry, so a position here would die exactly when a successor needed it.
+type Lease struct {
+	// Opaque and precomputed; Store implementations never parse it.
+	Key string
+	// The worker process that owns this lease.
+	Holder string
+	// Fencing token: increases on every Acquire or Renew, so a stale Lease
+	// loses any later CAS.
+	Revision uint64
+	// When this lease becomes eligible for another Acquire.
+	ExpiresAt time.Time
+}
+
+var ErrHeld = errors.New("lease already held by a live owner")
+
+var ErrFenced = errors.New("lease fenced: revision stale, another holder took over")
+
+// Ownership only. The lease path writes cursors via RenewAndPersistCursor.
+type Store interface {
+	Acquire(ctx context.Context, key, holder string, ttl time.Duration) (Lease, error)
+
+	Renew(ctx context.Context, l Lease, ttl time.Duration) (Lease, error)
+
+	Release(ctx context.Context, l Lease) error
+}

--- a/plugins/shared/crypto/cipher.go
+++ b/plugins/shared/crypto/cipher.go
@@ -1,0 +1,98 @@
+// Package crypto provides symmetric encryption for payloads crossing NATS.
+package crypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/sha1"
+	"encoding/base64"
+
+	"golang.org/x/crypto/pbkdf2"
+)
+
+const (
+	iterationCount = 65536
+	keyLength      = 16
+)
+
+// Derives both the AES-128-CBC key and its IV from one key string via PBKDF2.
+// This derivation must not change: it is the already-deployed scheme, so any
+// change makes existing ciphertext unreadable.
+type Cipher struct {
+	key []byte
+}
+
+func NewCipher(key string) *Cipher {
+	return &Cipher{key: []byte(key)}
+}
+
+func (c *Cipher) setKey() (cipher.Block, []byte, error) {
+	h := sha1.New()
+	h.Write(c.key)
+	salt := h.Sum(nil)
+	keyEnc := pbkdf2.Key(c.key, salt, iterationCount, keyLength, sha1.New)
+	block, err := aes.NewCipher(keyEnc)
+	if err != nil {
+		return nil, nil, err
+	}
+	return block, salt[:keyLength], nil
+}
+
+// Returns already-plaintext input unchanged rather than erroring, so values
+// written before a key was configured stay readable.
+func (c *Cipher) Decrypt(crypt string) (string, error) {
+	if crypt == "" {
+		return "", nil
+	}
+	encryptedData, err := base64.StdEncoding.DecodeString(crypt)
+	if err != nil {
+		return crypt, nil // not base64 -> already plaintext
+	}
+	blk, iv, err := c.setKey()
+	if err != nil {
+		return crypt, err
+	}
+	if len(encryptedData)%aes.BlockSize != 0 {
+		return crypt, nil // not a valid CBC block -> already plaintext
+	}
+	dec := cipher.NewCBCDecrypter(blk, iv)
+	decrypted := make([]byte, len(encryptedData))
+	dec.CryptBlocks(decrypted, encryptedData)
+	return string(pkcs5Trim(decrypted)), nil
+}
+
+func (c *Cipher) Encrypt(plain string) (string, error) {
+	if plain == "" {
+		return "", nil
+	}
+	blk, iv, err := c.setKey()
+	if err != nil {
+		return "", err
+	}
+	padded := pkcs5Pad([]byte(plain), aes.BlockSize)
+	enc := cipher.NewCBCEncrypter(blk, iv)
+	encrypted := make([]byte, len(padded))
+	enc.CryptBlocks(encrypted, padded)
+	return base64.StdEncoding.EncodeToString(encrypted), nil
+}
+
+func pkcs5Trim(data []byte) []byte {
+	if len(data) == 0 {
+		return data
+	}
+	padding := int(data[len(data)-1])
+	if padding > len(data) || padding == 0 {
+		return data
+	}
+	return data[:len(data)-padding]
+}
+
+func pkcs5Pad(data []byte, blockSize int) []byte {
+	padding := blockSize - len(data)%blockSize
+	padded := make([]byte, len(data)+padding)
+	copy(padded, data)
+	for i := len(data); i < len(padded); i++ {
+		padded[i] = byte(padding)
+	}
+	return padded
+}

--- a/plugins/shared/go.mod
+++ b/plugins/shared/go.mod
@@ -1,0 +1,15 @@
+module github.com/utmstack/UTMStack/plugins/shared
+
+go 1.25.5
+
+require (
+	github.com/nats-io/nats.go v1.53.1
+	golang.org/x/crypto v0.49.0
+)
+
+require (
+	github.com/klauspost/compress v1.18.5 // indirect
+	github.com/nats-io/nkeys v0.4.15 // indirect
+	github.com/nats-io/nuid v1.0.1 // indirect
+	golang.org/x/sys v0.42.0 // indirect
+)

--- a/plugins/shared/go.sum
+++ b/plugins/shared/go.sum
@@ -1,0 +1,12 @@
+github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBFW2IE=
+github.com/klauspost/compress v1.18.5/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
+github.com/nats-io/nats.go v1.53.1 h1:Otsq3uLc/kLdjmkNHkXH0jBqwUquwdKFoe3fq6/3/Xo=
+github.com/nats-io/nats.go v1.53.1/go.mod h1:26HypzazeOkyO3/mqd1zZd53STJN0EjCYF9Uy2ZOBno=
+github.com/nats-io/nkeys v0.4.15 h1:JACV5jRVO9V856KOapQ7x+EY8Jo3qw1vJt/9Jpwzkk4=
+github.com/nats-io/nkeys v0.4.15/go.mod h1:CpMchTXC9fxA5zrMo4KpySxNjiDVvr8ANOSZdiNfUrs=
+github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=
+github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
+golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=
+golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtCA=
+golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
+golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/plugins/shared/identity/hash.go
+++ b/plugins/shared/identity/hash.go
@@ -1,0 +1,17 @@
+// Package identity derives a deterministic event identity from source fields,
+// making a re-read event recognisable. Nothing collapses it today: utmstack.logs
+// is a MergeTree whose ORDER BY excludes id, and alert dedup is per-rule.
+package identity
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+// Hash returns hex(sha256(fields joined by "|")). Field content is not escaped,
+// and callers must include a tenant/group key so tenants cannot collide.
+func Hash(fields ...string) string {
+	sum := sha256.Sum256([]byte(strings.Join(fields, "|")))
+	return hex.EncodeToString(sum[:])
+}

--- a/plugins/sophos/config.go
+++ b/plugins/sophos/config.go
@@ -1,10 +1,6 @@
 package main
 
 import (
-	"crypto/aes"
-	"crypto/cipher"
-	"crypto/sha1"
-	"encoding/base64"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -14,13 +10,14 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/threatwinds/go-sdk/catcher"
 	"github.com/threatwinds/go-sdk/plugins"
-	"golang.org/x/crypto/pbkdf2"
+	"github.com/utmstack/UTMStack/plugins/shared/crypto"
 	"gopkg.in/yaml.v3"
 )
 
 const (
 	pluginFile         = "system_plugins_sophos.yaml"
-	processName        = "plugin_com.utmstack.sophos"
+	pluginName         = "com.utmstack.sophos"
+	processName        = "plugin_" + pluginName
 	pipelineDirDefault = "/workdir/pipeline"
 )
 
@@ -47,7 +44,24 @@ var (
 	cnf              *ConfigurationSection
 	mu               sync.Mutex
 	configUpdateChan chan *ConfigurationSection
+
+	encKeyMu  sync.RWMutex
+	encKeyVal string
 )
+
+// setEncryptionKey records the plugin-wide encryption key. Cursor payloads are
+// encrypted with it because the ingest_cursors bucket has no auth and no TLS.
+func setEncryptionKey(key string) {
+	encKeyMu.Lock()
+	defer encKeyMu.Unlock()
+	encKeyVal = key
+}
+
+func getEncryptionKey() string {
+	encKeyMu.RLock()
+	defer encKeyMu.RUnlock()
+	return encKeyVal
+}
 
 func init() {
 	configUpdateChan = make(chan *ConfigurationSection, 1)
@@ -68,8 +82,7 @@ func GetConfigUpdateChannel() <-chan *ConfigurationSection {
 	return configUpdateChan
 }
 
-// StartConfigurationSystem starts the file watcher. Blocks until configured,
-// then runs indefinitely.
+// StartConfigurationSystem blocks until configured, then watches indefinitely.
 func StartConfigurationSystem() {
 	pipelineDir := pipelineDirDefault
 	var encKey string
@@ -80,6 +93,7 @@ func StartConfigurationSystem() {
 				pipelineDir = d
 			}
 			encKey = cfg.Get("encryptionKey").String()
+			setEncryptionKey(encKey)
 			break
 		}
 		_ = catcher.Error("plugin configuration not found", nil, map[string]any{"process": processName})
@@ -88,7 +102,6 @@ func StartConfigurationSystem() {
 
 	filePath := filepath.Join(pipelineDir, pluginFile)
 
-	// Initial load.
 	if sec := readConfig(filePath, encKey); sec != nil {
 		mu.Lock()
 		cnf = sec
@@ -104,7 +117,7 @@ func StartConfigurationSystem() {
 	}
 	defer watcher.Close()
 
-	// Watch the directory so we catch atomic write (rename) events.
+	// Watch the directory, not the file, to catch atomic write (rename) events.
 	if err := watcher.Add(pipelineDir); err != nil {
 		_ = catcher.Error("failed to watch pipeline dir", err, map[string]any{"process": processName})
 		pollFallback(filePath, encKey)
@@ -140,7 +153,6 @@ func StartConfigurationSystem() {
 	}
 }
 
-// pollFallback is used if fsnotify setup fails — polls every 30s instead.
 func pollFallback(filePath, encKey string) {
 	catcher.Warn("falling back to 30s polling", map[string]any{"process": processName})
 	for range time.Tick(30 * time.Second) {
@@ -187,8 +199,7 @@ func readConfig(path, encKey string) *ConfigurationSection {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			// File removed → module disabled / no configuration. Report an empty,
-			// inactive section so the module is treated as disabled and all work stops.
+			// A removed file means the module is disabled, not a read failure.
 			return &ConfigurationSection{ModuleActive: false}
 		}
 		_ = catcher.Error("failed to read config file", err, map[string]any{"process": processName, "file": path})
@@ -215,7 +226,7 @@ func readConfig(path, encKey string) *ConfigurationSection {
 			for k, v := range g.Config {
 				conf := &Configuration{ConfKey: k, ConfValue: v}
 				if encKey != "" && sensitiveKeys[conf.ConfKey] {
-					if dec, err := NewCipher(encKey).Decrypt(conf.ConfValue); err == nil {
+					if dec, err := crypto.NewCipher(encKey).Decrypt(conf.ConfValue); err == nil {
 						conf.ConfValue = dec
 					}
 				}
@@ -224,68 +235,6 @@ func readConfig(path, encKey string) *ConfigurationSection {
 			sec.ModuleGroups = append(sec.ModuleGroups, grp)
 		}
 	}
-	// A tenant section with no groups must not read as configured.
 	sec.ModuleActive = len(sec.ModuleGroups) > 0
 	return sec
-}
-
-// ---------------------------------------------------------------------------
-// Cipher (merged from cipher.go)
-// ---------------------------------------------------------------------------
-
-const (
-	iterationCount = 65536
-	keyLength      = 16
-)
-
-type Cipher struct {
-	key []byte
-}
-
-func NewCipher(key string) *Cipher {
-	return &Cipher{key: []byte(key)}
-}
-
-func (c *Cipher) setKey() (cipher.Block, []byte, error) {
-	h := sha1.New()
-	h.Write(c.key)
-	salt := h.Sum(nil)
-	keyEnc := pbkdf2.Key(c.key, salt, iterationCount, keyLength, sha1.New)
-	block, err := aes.NewCipher(keyEnc)
-	if err != nil {
-		return nil, nil, err
-	}
-	return block, salt[:keyLength], nil
-}
-
-func (c *Cipher) Decrypt(crypt string) (string, error) {
-	if crypt == "" {
-		return "", nil
-	}
-	encryptedData, err := base64.StdEncoding.DecodeString(crypt)
-	if err != nil {
-		return crypt, nil // not base64 → already plaintext
-	}
-	blk, iv, err := c.setKey()
-	if err != nil {
-		return crypt, err
-	}
-	if len(encryptedData)%aes.BlockSize != 0 {
-		return crypt, nil // not a valid CBC block → already plaintext
-	}
-	dec := cipher.NewCBCDecrypter(blk, iv)
-	decrypted := make([]byte, len(encryptedData))
-	dec.CryptBlocks(decrypted, encryptedData)
-	return string(pkcs5Trim(decrypted)), nil
-}
-
-func pkcs5Trim(data []byte) []byte {
-	if len(data) == 0 {
-		return data
-	}
-	padding := int(data[len(data)-1])
-	if padding > len(data) || padding == 0 {
-		return data
-	}
-	return data[:len(data)-padding]
 }

--- a/plugins/sophos/cursor.go
+++ b/plugins/sophos/cursor.go
@@ -1,0 +1,36 @@
+package main
+
+import "time"
+
+// cursorKeyPrefix namespaces this plugin's keys in the shared bucket.
+const cursorKeyPrefix = "sophos."
+
+func sophosCursorKey(group *ModuleGroup) string {
+	return cursorKeyPrefix + group.Key()
+}
+
+// cursorSnapshot is the persisted position for one group: StartTime is the
+// event-time floor in Unix seconds (from_date), NextKey the pagination key
+// (pageFromKey). buildURL sends only one per request, so the floor is the
+// fallback when the key expires; both halves must always move together.
+type cursorSnapshot struct {
+	StartTime int64  `json:"startTime"`
+	NextKey   string `json:"nextKey"`
+}
+
+// floor must be the job's own window start, never time.Now(): a clock-derived
+// seed moves forward on every redelivery and silently skips whatever arrived
+// between failed attempts.
+func seedFrom(floor time.Time) cursorSnapshot {
+	return cursorSnapshot{StartTime: floor.Unix(), NextKey: ""}
+}
+
+// floor must be the tick's own end, not the worker's clock: it is the earlier
+// of the two, so a later fallback to from_date re-reads instead of skipping.
+func (s cursorSnapshot) advanced(nextKey string, floor time.Time) cursorSnapshot {
+	return cursorSnapshot{StartTime: floor.Unix(), NextKey: nextKey}
+}
+
+// A zero floor is a hazard, not a default: from_date=0 makes Sophos Central
+// return its entire retained history.
+func (s cursorSnapshot) usable() bool { return s.StartTime != 0 }

--- a/plugins/sophos/go.mod
+++ b/plugins/sophos/go.mod
@@ -6,9 +6,11 @@ require (
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/google/uuid v1.6.0
 	github.com/threatwinds/go-sdk v1.1.28
-	golang.org/x/crypto v0.55.0
+	github.com/utmstack/UTMStack/plugins/shared v0.0.0
 	gopkg.in/yaml.v3 v3.0.1
 )
+
+replace github.com/utmstack/UTMStack/plugins/shared => ../shared
 
 require (
 	cel.dev/expr v0.25.2 // indirect
@@ -28,11 +30,15 @@ require (
 	github.com/google/cel-go v0.28.1 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/nats-io/nats.go v1.53.1 // indirect
+	github.com/nats-io/nkeys v0.4.15 // indirect
+	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/opensearch-project/opensearch-go/v4 v4.6.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.3.1 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
@@ -46,6 +52,7 @@ require (
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/arch v0.27.0 // indirect
+	golang.org/x/crypto v0.55.0 // indirect
 	golang.org/x/exp v0.0.0-20260603202125-055de637280b // indirect
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect

--- a/plugins/sophos/go.sum
+++ b/plugins/sophos/go.sum
@@ -53,6 +53,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBFW2IE=
+github.com/klauspost/compress v1.18.5/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
 github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -68,6 +70,12 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/nats-io/nats.go v1.53.1 h1:Otsq3uLc/kLdjmkNHkXH0jBqwUquwdKFoe3fq6/3/Xo=
+github.com/nats-io/nats.go v1.53.1/go.mod h1:26HypzazeOkyO3/mqd1zZd53STJN0EjCYF9Uy2ZOBno=
+github.com/nats-io/nkeys v0.4.15 h1:JACV5jRVO9V856KOapQ7x+EY8Jo3qw1vJt/9Jpwzkk4=
+github.com/nats-io/nkeys v0.4.15/go.mod h1:CpMchTXC9fxA5zrMo4KpySxNjiDVvr8ANOSZdiNfUrs=
+github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=
+github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/opensearch-project/opensearch-go/v4 v4.6.0 h1:Ac8aLtDSmLEyOmv0r1qhQLw3b4vcUhE42NE9k+Z4cRc=
 github.com/opensearch-project/opensearch-go/v4 v4.6.0/go.mod h1:3iZtb4SNt3IzaxavKq0dURh1AmtVgYW71E4XqmYnIiQ=
 github.com/pelletier/go-toml/v2 v2.3.1 h1:MYEvvGnQjeNkRF1qUuGolNtNExTDwct51yp7olPtrEc=

--- a/plugins/sophos/identity.go
+++ b/plugins/sophos/identity.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"encoding/json"
+
+	"github.com/utmstack/UTMStack/plugins/shared/identity"
+)
+
+// LogRecord is one ingested Sophos Central event with its deterministic identity.
+type LogRecord struct {
+	ID  string
+	Raw string
+}
+
+// Marshaling and identifying stay in one function so Raw is exactly the bytes
+// eventIdentity hashed; computing them separately lets the two diverge.
+func newLogRecord(groupKey string, item map[string]any) (LogRecord, error) {
+	raw, err := json.Marshal(item)
+	if err != nil {
+		return LogRecord{}, err
+	}
+
+	return LogRecord{
+		ID:  eventIdentity(groupKey, item, raw),
+		Raw: string(raw),
+	}, nil
+}
+
+// eventIdentity gives the same source event the same id on every ingest, so a
+// re-read event is recognisable. Nothing downstream collapses it: utmstack.logs
+// does not order by id, and alert dedup is opt-in per rule. The "id"/"raw"
+// prefix keeps the two hash spaces disjoint.
+func eventIdentity(groupKey string, item map[string]any, raw []byte) string {
+	if nativeID, ok := item["id"].(string); ok && nativeID != "" {
+		return identity.Hash("id", groupKey, nativeID)
+	}
+	return identity.Hash("raw", groupKey, string(raw))
+}

--- a/plugins/sophos/main.go
+++ b/plugins/sophos/main.go
@@ -1,12 +1,11 @@
 package main
 
 import (
-	"encoding/json"
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
 	"runtime"
-	"strings"
 	"sync"
 	"time"
 
@@ -14,37 +13,59 @@ import (
 	"github.com/threatwinds/go-sdk/catcher"
 	"github.com/threatwinds/go-sdk/plugins"
 	"github.com/threatwinds/go-sdk/utils"
+	"github.com/utmstack/UTMStack/plugins/shared/coordination"
 )
 
 const (
-	authURL            = "https://id.sophos.com/api/v2/oauth2/token"
-	whoamiURL          = "https://api.central.sophos.com/whoami/v1"
-	defaultTenant      = "ce66672c-e36d-4761-a8c8-90058fee1a24"
-	urlCheckConnection = "https://id.sophos.com"
-	wait               = 3 * time.Second
+	authURL       = "https://id.sophos.com/api/v2/oauth2/token"
+	whoamiURL     = "https://api.central.sophos.com/whoami/v1"
+	defaultTenant = "ce66672c-e36d-4761-a8c8-90058fee1a24"
 )
 
-var (
-	nextKeys   = make(map[string]string)
-	nextKeysMu sync.RWMutex
+// tickInterval is how often jobs are published, and the width of a
+// first-activation window.
+const tickInterval = 5 * time.Minute
 
+var (
 	activeGroupsMu sync.RWMutex
 	activeGroups   = make(map[string]*ModuleGroup)
 )
 
+// coordinationRetryDelay paces retries while coordination is unreachable.
+const coordinationRetryDelay = 5 * time.Second
+
 func main() {
-	mode := plugins.GetCfg("plugin_com.utmstack.sophos").Env.Mode
-	if mode != "manager" {
+	mode := plugins.GetCfg(processName).Env.Mode
+	if mode != "worker" {
 		return
 	}
 
 	go StartConfigurationSystem()
 
 	for t := 0; t < 2*runtime.NumCPU(); t++ {
-		go plugins.SendLogsFromChannel("com.utmstack.sophos")
+		go plugins.SendLogsFromChannel(pluginName)
 	}
 
-	watchConfigAndPull()
+	ctx := context.Background()
+
+	// Retry forever and fail closed. Never turn this into a
+	// timeout-then-degrade path: ingesting without coordination means every
+	// replica pulls every group with no durable position.
+	coord, err := coordination.SetupWithRetry(ctx, coordination.DialQueuePath(processName, queuePlugin), coordinationRetryDelay,
+		func(err error) {
+			_ = catcher.Error("coordination setup failed, retrying", err, map[string]any{"process": processName})
+		})
+	if err != nil {
+		return
+	}
+	defer coord.Close()
+	logCoordinationReady()
+
+	// Runs on every replica regardless of the election below: the election
+	// only decides who publishes, not who ingests.
+	go runQueueConsumer(ctx, coord.Consumer, coord.Cursors, getEncryptionKey)
+
+	watchConfigAndPublish(coord.Scheduler, coord.Publisher, uuid.New().String())
 }
 
 func syncActiveGroups(newConfig *ConfigurationSection) {
@@ -53,7 +74,7 @@ func syncActiveGroups(newConfig *ConfigurationSection) {
 
 	if newConfig == nil || !newConfig.ModuleActive {
 		catcher.Info("Module deactivated, clearing all groups", map[string]any{
-			"process": "plugin_com.utmstack.sophos",
+			"process": processName,
 		})
 		activeGroups = make(map[string]*ModuleGroup)
 		return
@@ -68,7 +89,7 @@ func syncActiveGroups(newConfig *ConfigurationSection) {
 		if _, exists := newGroups[key]; !exists {
 			catcher.Info("Group removed from configuration", map[string]any{
 				"group":   key,
-				"process": "plugin_com.utmstack.sophos",
+				"process": processName,
 			})
 		}
 	}
@@ -77,7 +98,7 @@ func syncActiveGroups(newConfig *ConfigurationSection) {
 		if _, exists := activeGroups[key]; !exists {
 			catcher.Info("New group added to configuration", map[string]any{
 				"group":   key,
-				"process": "plugin_com.utmstack.sophos",
+				"process": processName,
 			})
 		}
 	}
@@ -96,7 +117,10 @@ func getActiveGroups() []*ModuleGroup {
 	return groups
 }
 
-func watchConfigAndPull() {
+// No connectivity pre-check here on purpose: blocking on id.sophos.com would
+// freeze the config-update branch. Failed pulls advance no cursor and ack no
+// job, so the window is simply redelivered.
+func watchConfigAndPublish(scheduler coordination.Store, publisher coordination.JobPublisher, holder string) {
 	time.Sleep(3 * time.Second)
 
 	initialConfig := GetConfig()
@@ -104,72 +128,57 @@ func watchConfigAndPull() {
 		syncActiveGroups(initialConfig)
 	}
 
-	delay := 5 * time.Minute
-	ticker := time.NewTicker(delay)
+	ticker := time.NewTicker(tickInterval)
 	defer ticker.Stop()
-
-	startTime := time.Now().UTC().Add(-delay)
 
 	for {
 		select {
 		case newConfig := <-GetConfigUpdateChannel():
 			catcher.Info("Received config update, syncing groups", map[string]any{
 				"moduleActive": newConfig != nil && newConfig.ModuleActive,
-				"process":      "plugin_com.utmstack.sophos",
+				"process":      processName,
 			})
 			syncActiveGroups(newConfig)
 
 		case <-ticker.C:
-			endTime := time.Now().UTC()
-
-			if err := connectionChecker(urlCheckConnection); err != nil {
-				_ = catcher.Error("External connection failure detected", err, map[string]any{"process": "plugin_com.utmstack.sophos"})
-				continue
-			}
-
 			groups := getActiveGroups()
 			if len(groups) == 0 {
-				catcher.Info("No active groups, skipping pull", map[string]any{
-					"process": "plugin_com.utmstack.sophos",
+				catcher.Info("No active groups, publishing nothing", map[string]any{
+					"process": processName,
 				})
-				startTime = endTime.Add(1 * time.Nanosecond)
 				continue
 			}
 
-			var wg sync.WaitGroup
-			wg.Add(len(groups))
-			for _, grp := range groups {
-				go func(group *ModuleGroup) {
-					defer wg.Done()
-					var invalid bool
-					for _, c := range group.ModuleGroupConfigurations {
-						if strings.TrimSpace(c.ConfValue) == "" {
-							invalid = true
-							break
-						}
-					}
-					if !invalid {
-						pull(startTime, group)
-					}
-				}(grp)
-			}
-			wg.Wait()
-
-			startTime = endTime.Add(1 * time.Nanosecond)
+			publishTickJobs(context.Background(), scheduler, publisher, holder, groups, time.Now().UTC())
 		}
 	}
 }
 
-func pull(startTime time.Time, group *ModuleGroup) {
-	nextKeysMu.RLock()
-	prevKey := nextKeys[group.Key()]
-	nextKeysMu.RUnlock()
+// ingestion isolates pull's side effects so the cursor rules stay testable.
+type ingestion struct {
+	fetch func(fromTime int64, nextKey string, groupKey string) ([]LogRecord, string, error)
+	emit  func(log *plugins.Log)
+}
 
+func liveIngestion(group *ModuleGroup) ingestion {
 	agent := getSophosCentralProcessor(group)
-	logs, newNextKey, err := agent.getLogs(startTime.Unix(), prevKey)
+	return ingestion{
+		fetch: func(fromTime int64, nextKey string, groupKey string) ([]LogRecord, string, error) {
+			return agent.getLogs(fromTime, nextKey, groupKey)
+		},
+		emit: func(log *plugins.Log) {
+			_ = plugins.EnqueueLog(log, pluginName)
+		},
+	}
+}
+
+func pull(group *ModuleGroup, floor int64, pageKey string, in ingestion) (string, int, error) {
+	records, nextKey, err := in.fetch(floor, pageKey, group.Key())
 	if err != nil {
-		_ = catcher.Error("error getting logs", err, map[string]any{"process": "plugin_com.utmstack.sophos"})
-		return
+		return "", 0, catcher.Error("error getting logs", err, map[string]any{
+			"process": processName,
+			"group":   group.Key(),
+		})
 	}
 
 	tenantId := group.TenantId
@@ -177,22 +186,18 @@ func pull(startTime time.Time, group *ModuleGroup) {
 		tenantId = defaultTenant
 	}
 
-	if len(logs) > 0 {
-		for _, log := range logs {
-			plugins.EnqueueLog(&plugins.Log{
-				Id:         uuid.New().String(),
-				TenantId:   tenantId,
-				DataType:   "sophos-central",
-				DataSource: group.GroupName,
-				Timestamp:  time.Now().UTC().Format(time.RFC3339Nano),
-				Raw:        log,
-			}, "com.utmstack.sophos")
-		}
+	for _, record := range records {
+		in.emit(&plugins.Log{
+			Id:         record.ID,
+			TenantId:   tenantId,
+			DataType:   "sophos-central",
+			DataSource: group.GroupName,
+			Timestamp:  time.Now().UTC().Format(time.RFC3339Nano),
+			Raw:        record.Raw,
+		})
 	}
 
-	nextKeysMu.Lock()
-	nextKeys[group.Key()] = newNextKey
-	nextKeysMu.Unlock()
+	return nextKey, len(records), nil
 }
 
 type SophosCentralProcessor struct {
@@ -229,7 +234,6 @@ func (p *SophosCentralProcessor) getAccessToken() (string, error) {
 		"Content-Type": "application/x-www-form-urlencoded",
 	}
 
-	// Retry logic for getting access token
 	maxRetries := 3
 	retryDelay := 2 * time.Second
 
@@ -251,26 +255,25 @@ func (p *SophosCentralProcessor) getAccessToken() (string, error) {
 		}
 
 		_ = catcher.Error("error getting access token, retrying", err, map[string]any{
-			"process":    "plugin_com.utmstack.sophos",
+			"process":    processName,
 			"retry":      retry + 1,
 			"maxRetries": maxRetries,
 		})
 
 		if retry < maxRetries-1 {
 			time.Sleep(retryDelay)
-			// Increase delay for next retry
 			retryDelay *= 2
 		}
 	}
 
 	if err != nil {
-		return "", catcher.Error("all retries failed when getting access token", err, map[string]any{"process": "plugin_com.utmstack.sophos"})
+		return "", catcher.Error("all retries failed when getting access token", err, map[string]any{"process": processName})
 	}
 
 	accessToken, ok := response["access_token"].(string)
 	if !ok || accessToken == "" {
 		return "", catcher.Error("access_token not found in response after all retries", nil, map[string]any{
-			"process":  "plugin_com.utmstack.sophos",
+			"process":  processName,
 			"response": response,
 		})
 	}
@@ -278,7 +281,7 @@ func (p *SophosCentralProcessor) getAccessToken() (string, error) {
 	expiresIn, ok := response["expires_in"].(float64)
 	if !ok {
 		return "", catcher.Error("expires_in not found in response after all retries", nil, map[string]any{
-			"process":  "plugin_com.utmstack.sophos",
+			"process":  processName,
 			"response": response,
 		})
 	}
@@ -304,7 +307,6 @@ func (p *SophosCentralProcessor) getTenantInfo(accessToken string) error {
 		"Authorization": "Bearer " + accessToken,
 	}
 
-	// Retry logic for getting tenant info
 	maxRetries := 3
 	retryDelay := 2 * time.Second
 
@@ -322,25 +324,24 @@ func (p *SophosCentralProcessor) getTenantInfo(accessToken string) error {
 		}
 
 		_ = catcher.Error("error getting tenant info, retrying", err, map[string]any{
-			"process":    "plugin_com.utmstack.sophos",
+			"process":    processName,
 			"retry":      retry + 1,
 			"maxRetries": maxRetries,
 		})
 
 		if retry < maxRetries-1 {
 			time.Sleep(retryDelay)
-			// Increase delay for next retry
 			retryDelay *= 2
 		}
 	}
 
 	if err != nil {
-		return catcher.Error("all retries failed when getting tenant info", err, map[string]any{"process": "plugin_com.utmstack.sophos"})
+		return catcher.Error("all retries failed when getting tenant info", err, map[string]any{"process": processName})
 	}
 
 	if response.ID == "" {
 		return catcher.Error("tenant ID not found in whoami response after all retries", nil, map[string]any{
-			"process":  "plugin_com.utmstack.sophos",
+			"process":  processName,
 			"response": response,
 		})
 	}
@@ -348,7 +349,7 @@ func (p *SophosCentralProcessor) getTenantInfo(accessToken string) error {
 
 	if response.ApiHosts.DataRegion == "" {
 		return catcher.Error("dataRegion not found in whoami response after all retries", nil, map[string]any{
-			"process":  "plugin_com.utmstack.sophos",
+			"process":  processName,
 			"response": response,
 		})
 	}
@@ -376,8 +377,7 @@ type Pages struct {
 	MaxSize int64  `json:"maxSize"`
 }
 
-func (p *SophosCentralProcessor) getLogs(fromTime int64, nextKey string) ([]string, string, error) {
-	// Retry logic for getting access token
+func (p *SophosCentralProcessor) getLogs(fromTime int64, nextKey string, groupKey string) ([]LogRecord, string, error) {
 	maxRetries := 3
 	retryDelay := 2 * time.Second
 
@@ -391,24 +391,22 @@ func (p *SophosCentralProcessor) getLogs(fromTime int64, nextKey string) ([]stri
 		}
 
 		_ = catcher.Error("error getting access token, retrying", err, map[string]any{
-			"process":    "plugin_com.utmstack.sophos",
+			"process":    processName,
 			"retry":      retry + 1,
 			"maxRetries": maxRetries,
 		})
 
 		if retry < maxRetries-1 {
 			time.Sleep(retryDelay)
-			// Increase delay for next retry
 			retryDelay *= 2
 		}
 	}
 
 	if err != nil {
-		return nil, "", catcher.Error("all retries failed when getting access token", err, map[string]any{"process": "plugin_com.utmstack.sophos"})
+		return nil, "", catcher.Error("all retries failed when getting access token", err, map[string]any{"process": processName})
 	}
 
 	if p.TenantID == "" || p.DataRegion == "" {
-		// Retry logic for getting tenant info
 		for retry := 0; retry < maxRetries; retry++ {
 			err = p.getTenantInfo(accessToken)
 			if err == nil {
@@ -416,24 +414,23 @@ func (p *SophosCentralProcessor) getLogs(fromTime int64, nextKey string) ([]stri
 			}
 
 			_ = catcher.Error("error getting tenant info, retrying", err, map[string]any{
-				"process":    "plugin_com.utmstack.sophos",
+				"process":    processName,
 				"retry":      retry + 1,
 				"maxRetries": maxRetries,
 			})
 
 			if retry < maxRetries-1 {
 				time.Sleep(retryDelay)
-				// Increase delay for next retry
 				retryDelay *= 2
 			}
 		}
 
 		if err != nil {
-			return nil, "", catcher.Error("all retries failed when getting tenant info", err, map[string]any{"process": "plugin_com.utmstack.sophos"})
+			return nil, "", catcher.Error("all retries failed when getting tenant info", err, map[string]any{"process": processName})
 		}
 	}
 
-	logs := make([]string, 0, 1000)
+	records := make([]LogRecord, 0, 1000)
 
 	for {
 		u, err := p.buildURL(fromTime, nextKey)
@@ -447,7 +444,6 @@ func (p *SophosCentralProcessor) getLogs(fromTime int64, nextKey string) ([]stri
 			"X-Tenant-ID":   p.TenantID,
 		}
 
-		// Retry logic for getting logs
 		var response EventAggregate
 		for retry := 0; retry < maxRetries; retry++ {
 			response, _, err = utils.DoReq[EventAggregate](u.String(), nil, http.MethodGet, headers, false)
@@ -456,29 +452,28 @@ func (p *SophosCentralProcessor) getLogs(fromTime int64, nextKey string) ([]stri
 			}
 
 			_ = catcher.Error("error getting logs, retrying", err, map[string]any{
-				"process":    "plugin_com.utmstack.sophos",
+				"process":    processName,
 				"retry":      retry + 1,
 				"maxRetries": maxRetries,
 			})
 
 			if retry < maxRetries-1 {
 				time.Sleep(retryDelay)
-				// Increase delay for next retry
 				retryDelay *= 2
 			}
 		}
 
 		if err != nil {
-			return nil, "", catcher.Error("all retries failed when getting logs", err, map[string]any{"process": "plugin_com.utmstack.sophos"})
+			return nil, "", catcher.Error("all retries failed when getting logs", err, map[string]any{"process": processName})
 		}
 
 		for _, item := range response.Items {
-			jsonItem, err := json.Marshal(item)
+			record, err := newLogRecord(groupKey, item)
 			if err != nil {
-				_ = catcher.Error("error marshalling content details", err, map[string]any{"process": "plugin_com.utmstack.sophos"})
+				_ = catcher.Error("error marshalling content details", err, map[string]any{"process": processName})
 				continue
 			}
-			logs = append(logs, string(jsonItem))
+			records = append(records, record)
 		}
 
 		if response.Pages.NextKey == "" {
@@ -487,7 +482,7 @@ func (p *SophosCentralProcessor) getLogs(fromTime int64, nextKey string) ([]stri
 		nextKey = response.Pages.NextKey
 	}
 
-	return logs, nextKey, nil
+	return records, nextKey, nil
 }
 
 func (p *SophosCentralProcessor) buildURL(fromTime int64, nextKey string) (*url.URL, error) {
@@ -495,7 +490,7 @@ func (p *SophosCentralProcessor) buildURL(fromTime int64, nextKey string) (*url.
 	u, parseErr := url.Parse(baseURL)
 	if parseErr != nil {
 		return nil, catcher.Error("error parsing url", parseErr, map[string]any{
-			"process": "sophos-plugin",
+			"process": processName,
 			"url":     baseURL,
 		})
 	}
@@ -509,70 +504,4 @@ func (p *SophosCentralProcessor) buildURL(fromTime int64, nextKey string) (*url.
 
 	u.RawQuery = params.Encode()
 	return u, nil
-}
-
-func connectionChecker(url string) error {
-	checkConn := func() error {
-		if err := checkConnection(url); err != nil {
-			return fmt.Errorf("connection failed: %v", err)
-		}
-		return nil
-	}
-
-	if err := infiniteRetryIfXError(checkConn, "connection failed"); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func checkConnection(url string) error {
-	client := &http.Client{
-		Timeout: 30 * time.Second,
-	}
-
-	req, err := http.NewRequest(http.MethodGet, url, nil)
-	if err != nil {
-		return err
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		err := resp.Body.Close()
-		if err != nil {
-			_ = catcher.Error("error closing response body", err, map[string]any{"process": "plugin_com.utmstack.sophos"})
-		}
-	}()
-
-	return nil
-}
-
-func infiniteRetryIfXError(f func() error, exception string) error {
-	var xErrorWasLogged bool
-
-	for {
-		err := f()
-		if err != nil && is(err, exception) {
-			if !xErrorWasLogged {
-				_ = catcher.Error("An error occurred, will keep retrying indefinitely...", err, map[string]any{"process": "plugin_com.utmstack.sophos"})
-				xErrorWasLogged = true
-			}
-			time.Sleep(wait)
-			continue
-		}
-
-		return err
-	}
-}
-
-func is(e error, args ...string) bool {
-	for _, arg := range args {
-		if strings.Contains(e.Error(), arg) {
-			return true
-		}
-	}
-	return false
 }

--- a/plugins/sophos/queue.go
+++ b/plugins/sophos/queue.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/threatwinds/go-sdk/catcher"
+	"github.com/utmstack/UTMStack/plugins/shared/coordination"
+)
+
+const (
+	jobConsumedMsg       = "job consumed, cursor advanced"
+	coordinationReadyMsg = "coordination ready, consuming jobs"
+
+	// queuePlugin names the NATS stream, subjects, durable consumer and
+	// scheduler election key. Changing it orphans all of them on an existing
+	// deployment.
+	queuePlugin = "sophos"
+)
+
+func logCoordinationReady() {
+	catcher.Info(coordinationReadyMsg, map[string]any{
+		"process":        processName,
+		"plugin":         queuePlugin,
+		"schedulerLease": coordination.SchedulerLeaseKey(queuePlugin),
+	})
+}
+
+// WindowStart is a first-activation hint only: once a group has a cursor it is
+// ignored, since only the cursor knows where the previous worker got to.
+func jobsForGroups(groups []*ModuleGroup, windowEnd time.Time) []coordination.Job {
+	jobs := make([]coordination.Job, 0, len(groups))
+	for _, group := range groups {
+		jobs = append(jobs, coordination.Job{
+			TenantID:    group.TenantId,
+			GroupName:   group.GroupName,
+			WindowStart: windowEnd.Add(-tickInterval),
+			WindowEnd:   windowEnd,
+		})
+	}
+	return jobs
+}
+
+func publishTickJobs(ctx context.Context, scheduler coordination.Store, publisher coordination.JobPublisher, holder string, groups []*ModuleGroup, windowEnd time.Time) {
+	coordination.PublishJobsIfElected(ctx, scheduler, publisher,
+		coordination.SchedulerLeaseKey(queuePlugin), holder,
+		jobsForGroups(groups, windowEnd),
+		func(job coordination.Job, err error) {
+			_ = catcher.Error("error publishing job", err, map[string]any{
+				"process": processName,
+				"group":   job.TenantID + "/" + job.GroupName,
+			})
+		})
+}
+
+func resolveGroup(tenantId, groupName string) (*ModuleGroup, bool) {
+	activeGroupsMu.RLock()
+	defer activeGroupsMu.RUnlock()
+	group, ok := activeGroups[tenantId+"/"+groupName]
+	return group, ok
+}
+
+func hasCompleteCredentials(group *ModuleGroup) bool {
+	for _, c := range group.ModuleGroupConfigurations {
+		if strings.TrimSpace(c.ConfValue) == "" {
+			return false
+		}
+	}
+	return true
+}
+
+// Load/work/Save/Ack ordering is owned by ConsumeAndAdvanceCursor: saving
+// before the pull completes moves the position past data never ingested.
+func consumeJob(
+	ctx context.Context,
+	cursors coordination.CursorStore,
+	delivery coordination.JobDelivery,
+	group *ModuleGroup,
+	in ingestion,
+	encryptionKey string,
+) error {
+	key := sophosCursorKey(group)
+
+	// Captured by whichever callback ran; ConsumeWork cannot return them.
+	var floorFrom, floorTo int64
+	var ingested int
+
+	pullFrom := func(from cursorSnapshot, windowEnd time.Time) ([]byte, error) {
+		nextKey, records, err := pull(group, from.StartTime, from.NextKey, in)
+		if err != nil {
+			return nil, err
+		}
+		advanced := from.advanced(nextKey, windowEnd)
+		floorFrom, floorTo, ingested = from.StartTime, advanced.StartTime, records
+		return coordination.MarshalCursorPayload(advanced, encryptionKey)
+	}
+
+	work := coordination.ConsumeWork{
+		Activate: func(ctx context.Context, job coordination.Job) ([]byte, error) {
+			return pullFrom(seedFrom(job.WindowStart), job.WindowEnd)
+		},
+
+		// A persisted position is authoritative and inherited unchanged.
+		// Re-seeding it from job.WindowStart would discard the backlog the
+		// stored continuation key exists to fetch.
+		Resume: func(ctx context.Context, job coordination.Job, cur coordination.Cursor) ([]byte, error) {
+			persisted, err := coordination.UnmarshalCursorPayload[cursorSnapshot](cur.Data, encryptionKey)
+			if err != nil {
+				return nil, err
+			}
+			if !persisted.usable() {
+				// Fail closed. Re-seeding from now would skip everything
+				// since the last real position; adopting the zero floor
+				// would request Sophos Central's whole retained history.
+				return nil, fmt.Errorf("refusing to ingest %s from a cursor with no event-time floor", group.Key())
+			}
+			return pullFrom(persisted, job.WindowEnd)
+		},
+	}
+
+	if err := coordination.ConsumeAndAdvanceCursor(ctx, cursors, delivery, key, work); err != nil {
+		return err
+	}
+
+	// Only here, after the cursor is durable and the job acked. Logging from
+	// inside pullFrom would report success for a cycle that then lost its CAS.
+	catcher.Info(jobConsumedMsg, map[string]any{
+		"process":     processName,
+		"group":       group.Key(),
+		"windowStart": floorFrom,
+		"windowEnd":   floorTo,
+		"records":     ingested,
+	})
+	return nil
+}
+
+func handleJob(ctx context.Context, cursors coordination.CursorStore, delivery coordination.JobDelivery, encryptionKeyFn func() string) error {
+	group, ok := resolveGroup(delivery.Job.TenantID, delivery.Job.GroupName)
+	if !ok {
+		// Group not configured here: no Ack and no Nak, so AckWait redelivers
+		// it to a worker that has it, and MaxDeliver drops it if none does.
+		return nil
+	}
+
+	if !hasCompleteCredentials(group) {
+		// Same treatment: a group that cannot authenticate must not have its
+		// position advanced, nor be acked as though its window was ingested.
+		return nil
+	}
+
+	return consumeJob(ctx, cursors, delivery, group, liveIngestion(group), encryptionKeyFn())
+}
+
+func runQueueConsumer(ctx context.Context, consumer coordination.JobConsumer, cursors coordination.CursorStore, encryptionKeyFn func() string) {
+	coordination.RunJobConsumer(ctx, consumer,
+		func(ctx context.Context, delivery coordination.JobDelivery) error {
+			return handleJob(ctx, cursors, delivery, encryptionKeyFn)
+		},
+		func(err error) {
+			_ = catcher.Error("error consuming job", err, map[string]any{"process": processName})
+		})
+}


### PR DESCRIPTION
## What

The four pull-based ingestion plugins (aws, o365, crowdstrike, sophos) now run in
worker mode and coordinate ownership over NATS JetStream, so multiple
event-processor replicas no longer duplicate or drop work.

- New `plugins/shared` module: lease store, cursor store, job queue, scheduler.
- **Lease path** (aws, crowdstrike): a worker acquires a per-unit lease before
  streaming, renews it on a heartbeat, and stops as soon as it is fenced.
- **Queue path** (o365, sophos): one elected scheduler publishes a job per group
  per tick; any worker may consume it.
- The ingestion position moves from an in-memory variable to a persisted
  per-group cursor.
- Event ids are derived from the event's own fields instead of a fresh UUID.

## Why

Each replica used to run the full ingestion loop independently, and the position
lived in a local variable: on restart a plugin resumed at `now - interval`, so
anything that arrived while it was down was never read. Persisting the cursor
lets a replica resume where the previous one stopped; the lease and queue paths
decide which replica does the work.

On failover the design prefers re-reading over skipping — a duplicate is noise,
a gap is an attack nobody saw. Deterministic event ids are what keep those
re-reads recognisable. 