### PR TITLE
pfSense filter fix

### DIFF
--- a/filters/pfsense/pfsense_fw.yml
+++ b/filters/pfsense/pfsense_fw.yml
@@ -33,7 +33,9 @@ pipeline:
           source: raw
           where: regexMatch("raw", "\\d{4}-\\d{2}-\\d{2}")
 
-      # Parsing syslog format date (OPNsense/pfSense)
+      #......................................................................#
+      # Parsing syslog format date (OPNsense/pfSense) — BSD WITH hostname
+      #......................................................................#
       - grok:
           patterns:
             - fieldName: log.priority
@@ -45,7 +47,21 @@ pipeline:
             - fieldName: log.msgAll
               pattern: '{{.greedy}}'
           source: raw
-          where: regexMatch("raw", "<\\d+>[A-Z][a-z]{2}\\s+\\d{1,2}\\s+\\d{2}")
+          where: regexMatch("raw", "<\\d+>[A-Z][a-z]{2}\\s+\\d{1,2}\\s+\\d{2}:\\d{2}:\\d{2}\\s+\\S+\\s+\\S+[\\[:]")
+
+      #......................................................................#
+      # Parsing syslog format date (OPNsense/pfSense) — BSD WITHOUT hostname
+      #......................................................................#
+      - grok:
+          patterns:
+            - fieldName: log.priority
+              pattern: '\<{{.integer}}\>'
+            - fieldName: log.deviceTime
+              pattern: '{{.monthName}}{{.space}}{{.monthDay}}{{.space}}{{.time}}{{.space}}'
+            - fieldName: log.msgAll
+              pattern: '{{.greedy}}'
+          source: raw
+          where: regexMatch("raw", "<\\d+>[A-Z][a-z]{2}\\s+\\d{1,2}\\s+\\d{2}:\\d{2}:\\d{2}\\s+[^\\s\\[:]+[\\[:]")
 
       #......................................................................#
       # Removing unnecessary characters of the syslogHeader
@@ -131,7 +147,7 @@ pipeline:
             - log.tcpWindow
             - log.urg
             - log.tcpOptions
-          where: regexMatch("log.csvMsg", "(.+),(\\s)?(match|\\w+),(block|pass),(in|out),(4|6),(.+)(tcp|TCP|Tcp)")
+          where: regexMatch("log.csvMsg", "(.+),(\\s)?(match|\\w+),(block|pass),(in|out),4,(.+)(tcp|TCP|Tcp)")
 
       # .......................................................................#
       - csv:
@@ -161,7 +177,7 @@ pipeline:
             - log.srcPort
             - log.dstPort
             - log.dataLength
-          where: regexMatch("log.csvMsg", "(.+),(\\s)?(match|\\w+),(block|pass),(in|out),(4|6),(.+)(udp|UDP|Udp)")
+          where: regexMatch("log.csvMsg", "(.+),(\\s)?(match|\\w+),(block|pass),(in|out),4,(.+)(udp|UDP|Udp)")
 
       #......................................................................#
       - csv:
@@ -194,7 +210,7 @@ pipeline:
             - log.icmpData3
             - log.icmpData4
             - log.icmpData5
-          where: regexMatch("log.csvMsg", "(.+),(\\s)?(match|\\w+),(block|pass),(in|out),(4|6),(.+)(icmp|ICMP|Icmp)")
+          where: regexMatch("log.csvMsg", "(.+),(\\s)?(match|\\w+),(block|pass),(in|out),4,(.+)(icmp|ICMP|Icmp)")
 
       #......................................................................#
       - csv:
@@ -227,7 +243,7 @@ pipeline:
             - log.tcpWindow
             - log.urg
             - log.tcpOptions
-          where: regexMatch("log.csvMsg", "(.+),(\\s)?(match|\\w+),(block|pass),(in|out),(6|17),(.+)(tcp|TCP|Tcp)")
+          where: regexMatch("log.csvMsg", "(.+),(\\s)?(match|\\w+),(block|pass),(in|out),6,(.+)(tcp|TCP|Tcp)")
       
       #......................................................................#
       - csv:
@@ -254,7 +270,7 @@ pipeline:
             - log.srcPort
             - log.dstPort
             - log.dataLength
-          where: regexMatch("log.csvMsg", "(.+),(match|\\w+),(block|pass),(in|out),6,(.+)(udp|UDP|Udp)") 
+          where: regexMatch("log.csvMsg", "(.+),(\\s)?(match|\\w+),(block|pass),(in|out),6,(.+)(udp|UDP|Udp)")
 
       #......................................................................#
       - csv:
@@ -284,7 +300,7 @@ pipeline:
             - log.icmpData3
             - log.icmpData4
             - log.icmpData5
-          where: regexMatch("log.csvMsg", "(.+),(match|\\w+),(block|pass),(in|out),(6|17),(.+)(icmp|ICMP|Icmp)")
+          where: regexMatch("log.csvMsg", "(.+),(\\s)?(match|\\w+),(block|pass),(in|out),6,(.+)(icmp|ICMP|Icmp)")
 
       # ................................................#
       # Rename fields


### PR DESCRIPTION
## Detailed explanation of the changes

The pfSense filter (`filters/pfsense/pfsense_fw.yml`) was adjusted in two ways:

1. **Syslog header without hostname**: A variant of the header parser was added to recognize events where pfSense sends the log directly with the process (`filterlog[...]`) without including the hostname.

2. **IPv4/IPv6 variant separation**: The conditions that determine which message format to apply (TCP, UDP, ICMP for IPv4 and IPv6) were adjusted so that each event only enters the correct variant. Previously, some conditions overlapped and caused parsing errors when an IPv6 event mistakenly fell into an IPv4 variant.

## Reasoning behind these changes

pfSense events arriving without a hostname in the header were not parsed. Additionally, even when the header was successfully parsed, some IPv6 events triggered a "column index out of range" error because multiple format variants were competing for the same event.

With these adjustments:

- Both pfSense header formats (with and without hostname) are supported, without breaking compatibility with logs that were already parsing correctly.

- Each event is processed by only one parser variant, eliminating the column index error and ensuring that fields are populated correctly for correlation rules.

## Issue reference

_#1852_