### PR TITLE
fix(o365): resume collection from a persisted checkpoint and follow content-list pagination

### DIFF
--- a/plugins/o365/collect.go
+++ b/plugins/o365/collect.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"sync"
+	"time"
+
+	"github.com/threatwinds/go-sdk/catcher"
+	"github.com/utmstack/UTMStack/plugins/o365/config"
+)
+
+type windowPositions struct {
+	mu   sync.Mutex
+	path string
+	at   map[int32]persistedGroup
+}
+
+func newWindowPositions(path string) *windowPositions {
+	return &windowPositions{path: path, at: loadPositions(path)}
+}
+
+func (w *windowPositions) positionFor(groupID int32, seed time.Time) time.Time {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	position, seen := w.at[groupID]
+	if !seen {
+		w.at[groupID] = persistedGroup{WindowEnd: seed}
+		return seed
+	}
+	return position.WindowEnd
+}
+
+func (w *windowPositions) advanceTo(group *config.ModuleGroup, at time.Time) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	w.at[group.Id] = persistedGroup{GroupName: group.GroupName, WindowEnd: at}
+	savePositions(w.path, w.at)
+}
+
+func (w *windowPositions) retain(groupIDs map[int32]struct{}) {
+	// An empty list means the configuration has not loaded yet, so pruning would recreate the gap.
+	if len(groupIDs) == 0 {
+		return
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	dropped := false
+	for id := range w.at {
+		if _, configured := groupIDs[id]; !configured {
+			delete(w.at, id)
+			dropped = true
+		}
+	}
+
+	if dropped {
+		savePositions(w.path, w.at)
+	}
+}
+
+type pullFunc func(startTime, endTime time.Time, group *config.ModuleGroup) error
+
+func collectGroup(positions *windowPositions, group *config.ModuleGroup, now, seed time.Time, doPull pullFunc) {
+	position := positions.positionFor(group.Id, seed)
+
+	if oldest := now.Add(-maxCollectionLookback); position.Before(oldest) {
+		_ = catcher.Error("collection position was older than the lookback limit, that much backlog was skipped", nil, map[string]any{
+			"process":   "plugin_com.utmstack.o365",
+			"group":     group.GroupName,
+			"skipped":   oldest.Sub(position).String(),
+			"from":      position.Format(time.RFC3339),
+			"resumedAt": oldest.Format(time.RFC3339),
+		})
+
+		position = oldest
+		positions.advanceTo(group, oldest)
+	}
+
+	start, end, ok := nextWindow(position, now, maxCollectionWindow)
+	if !ok {
+		return
+	}
+
+	// Leaving the position at a failed window's start is what makes that range retryable.
+	if err := doPull(start, end, group); err != nil {
+		return
+	}
+
+	positions.advanceTo(group, end)
+}

--- a/plugins/o365/main.go
+++ b/plugins/o365/main.go
@@ -149,7 +149,7 @@ func watchConfigAndPull() {
 	ticker := time.NewTicker(delay)
 	defer ticker.Stop()
 
-	startTime := time.Now().UTC().Add(-delay)
+	positions := newWindowPositions(defaultStatePath())
 
 	for {
 		select {
@@ -161,14 +161,19 @@ func watchConfigAndPull() {
 			syncActiveGroups(newConfig)
 
 		case <-ticker.C:
-			endTime := time.Now().UTC()
-
+			now := time.Now().UTC()
 			groups := getActiveGroups()
+
+			configured := make(map[int32]struct{}, len(groups))
+			for _, grp := range groups {
+				configured[grp.Id] = struct{}{}
+			}
+			positions.retain(configured)
+
 			if len(groups) == 0 {
 				catcher.Info("No active groups, skipping pull", map[string]any{
 					"process": "plugin_com.utmstack.o365",
 				})
-				startTime = endTime.Add(1 * time.Nanosecond)
 				continue
 			}
 
@@ -180,12 +185,11 @@ func watchConfigAndPull() {
 			for _, grp := range groups {
 				go func(group *config.ModuleGroup) {
 					defer wg.Done()
-					pull(startTime, endTime, group)
+					collectGroup(positions, group, now, now.Add(-delay), pull)
 				}(grp)
 			}
 
 			wg.Wait()
-			startTime = endTime.Add(1 * time.Nanosecond)
 		}
 	}
 }
@@ -219,22 +223,18 @@ func getGroupEnvironment(group *config.ModuleGroup) CloudEnvironment {
 	return CloudCommercial
 }
 
-func pull(startTime time.Time, endTime time.Time, group *config.ModuleGroup) {
+func pull(startTime time.Time, endTime time.Time, group *config.ModuleGroup) error {
 	agent := GetOfficeProcessor(group)
 
-	err := agent.GetAuth()
-	if err != nil {
-		_ = catcher.Error("error getting auth", err, map[string]any{"process": "plugin_com.utmstack.o365"})
-		return
+	if err := agent.GetAuth(); err != nil {
+		return catcher.Error("error getting auth", err, map[string]any{"process": "plugin_com.utmstack.o365"})
 	}
 
-	err = agent.StartSubscriptions()
-	if err != nil {
-		_ = catcher.Error("error starting subscriptions", err, map[string]any{"process": "plugin_com.utmstack.o365"})
-		return
+	if err := agent.StartSubscriptions(); err != nil {
+		return catcher.Error("error starting subscriptions", err, map[string]any{"process": "plugin_com.utmstack.o365"})
 	}
 
-	logs := agent.GetLogs(startTime, endTime)
+	logs, err := agent.GetLogs(startTime, endTime)
 	for _, log := range logs {
 		plugins.EnqueueLog(&plugins.Log{
 			Id:         uuid.New().String(),
@@ -245,6 +245,8 @@ func pull(startTime time.Time, endTime time.Time, group *config.ModuleGroup) {
 			Raw:        log,
 		}, "com.utmstack.o365")
 	}
+
+	return err
 }
 
 type OfficeProcessor struct {
@@ -483,6 +485,8 @@ func (o *OfficeProcessor) validateNextPageUri(nextPageUri string) error {
 	return nil
 }
 
+var contentRetryDelay = 2 * time.Second
+
 func (o *OfficeProcessor) getContentListPage(link string, subscription string) ([]ContentList, http.Header, error) {
 	headers := map[string]string{
 		"Content-Type":  "application/json",
@@ -490,7 +494,7 @@ func (o *OfficeProcessor) getContentListPage(link string, subscription string) (
 	}
 
 	maxRetries := 3
-	retryDelay := 2 * time.Second
+	retryDelay := contentRetryDelay
 
 	var respBody []ContentList
 	var respHeaders http.Header
@@ -530,9 +534,8 @@ func (o *OfficeProcessor) GetContentDetails(url string) (ContentDetailsResponse,
 		"Authorization": fmt.Sprintf("%s %s", o.Credentials.TokenType, o.Credentials.AccessToken),
 	}
 
-	// Retry logic for getting content details
 	maxRetries := 3
-	retryDelay := 2 * time.Second
+	retryDelay := contentRetryDelay
 
 	var respBody ContentDetailsResponse
 	var status int
@@ -540,7 +543,7 @@ func (o *OfficeProcessor) GetContentDetails(url string) (ContentDetailsResponse,
 
 	for retry := 0; retry < maxRetries; retry++ {
 		respBody, status, err = utils.DoReq[ContentDetailsResponse](url, nil, http.MethodGet, headers, false)
-		if err == nil {
+		if err == nil && status == http.StatusOK {
 			return respBody, nil
 		}
 
@@ -554,7 +557,6 @@ func (o *OfficeProcessor) GetContentDetails(url string) (ContentDetailsResponse,
 
 		if retry < maxRetries-1 {
 			time.Sleep(retryDelay)
-			// Increase delay for next retry
 			retryDelay *= 2
 		}
 	}
@@ -566,34 +568,47 @@ func (o *OfficeProcessor) GetContentDetails(url string) (ContentDetailsResponse,
 	})
 }
 
-func (o *OfficeProcessor) GetLogs(startTime, endTime time.Time) []string {
+func (o *OfficeProcessor) GetLogs(startTime, endTime time.Time) ([]string, error) {
 	logs := make([]string, 0, 10)
+	incomplete := false
+
 	for _, subscription := range o.Subscriptions {
 		contentList, err := o.GetContentList(subscription, startTime, endTime)
 		if err != nil {
 			_ = catcher.Error("error getting content list", err, map[string]any{"process": "plugin_com.utmstack.o365"})
+			incomplete = true
 			continue
 		}
 
-		if len(contentList) > 0 {
-			for _, log := range contentList {
-				details, err := o.GetContentDetails(log.ContentUri)
+		for _, log := range contentList {
+			details, err := o.GetContentDetails(log.ContentUri)
+			if err != nil {
+				_ = catcher.Error("error getting content details", err, map[string]any{"process": "plugin_com.utmstack.o365"})
+				incomplete = true
+				continue
+			}
+
+			for _, detail := range details {
+				rawDetail, err := json.Marshal(detail)
 				if err != nil {
-					_ = catcher.Error("error getting content details", err, map[string]any{"process": "plugin_com.utmstack.o365"})
+					_ = catcher.Error("error marshalling content details", err, map[string]any{"process": "plugin_com.utmstack.o365"})
+					incomplete = true
 					continue
 				}
-				if len(details) > 0 {
-					for _, detail := range details {
-						rawDetail, err := json.Marshal(detail)
-						if err != nil {
-							_ = catcher.Error("error marshalling content details", err, map[string]any{"process": "plugin_com.utmstack.o365"})
-							continue
-						}
-						logs = append(logs, string(rawDetail))
-					}
-				}
+
+				logs = append(logs, string(rawDetail))
 			}
 		}
 	}
-	return logs
+
+	if incomplete {
+		return logs, catcher.Error("collection incomplete for the requested window", nil, map[string]any{
+			"process":   "plugin_com.utmstack.o365",
+			"startTime": startTime.Format(time.RFC3339),
+			"endTime":   endTime.Format(time.RFC3339),
+			"collected": len(logs),
+		})
+	}
+
+	return logs, nil
 }

--- a/plugins/o365/main.go
+++ b/plugins/o365/main.go
@@ -377,9 +377,8 @@ func (o *OfficeProcessor) StartSubscriptions() error {
 			"Authorization": fmt.Sprintf("%s %s", o.Credentials.TokenType, o.Credentials.AccessToken),
 		}
 
-		// Retry logic for starting subscriptions
 		maxRetries := 3
-		retryDelay := 2 * time.Second
+		retryDelay := contentRetryDelay
 
 		var err error
 
@@ -389,9 +388,10 @@ func (o *OfficeProcessor) StartSubscriptions() error {
 				break
 			}
 
-			// If the subscription is already enabled, that's not an error
+			// Microsoft reports an already enabled subscription as HTTP 400.
 			if strings.Contains(err.Error(), "subscription is already enabled") {
-				return nil
+				err = nil
+				break
 			}
 
 			_ = catcher.Error("error starting subscription, retrying", err, map[string]any{
@@ -403,7 +403,6 @@ func (o *OfficeProcessor) StartSubscriptions() error {
 
 			if retry < maxRetries-1 {
 				time.Sleep(retryDelay)
-				// Increase delay for next retry
 				retryDelay *= 2
 			}
 		}

--- a/plugins/o365/main.go
+++ b/plugins/o365/main.go
@@ -26,6 +26,7 @@ const (
 	endPointContent                            = "/activity/feed/subscriptions/content"
 	DefaultTenant                              = "ce66672c-e36d-4761-a8c8-90058fee1a24"
 	apiVersion                                 = "api/v1.0/"
+	maxContentListPages                        = 1000
 	CloudCommercial           CloudEnvironment = "Commercial"
 	CloudGCC                  CloudEnvironment = "GCC"
 	CloudGCCHigh              CloudEnvironment = "GCCHigh"
@@ -426,23 +427,80 @@ func (o *OfficeProcessor) GetContentList(subscription string, startTime time.Tim
 		endTime.UTC().Format("2006-01-02T15:04:05"),
 		subscription)
 
+	contentList := make([]ContentList, 0, 10)
+
+	for page := 0; page < maxContentListPages; page++ {
+		entries, respHeaders, err := o.getContentListPage(link, subscription)
+		if err != nil {
+			return []ContentList{}, err
+		}
+
+		contentList = append(contentList, entries...)
+
+		nextPageUri := respHeaders.Get("NextPageUri")
+		if nextPageUri == "" {
+			return contentList, nil
+		}
+
+		if err := o.validateNextPageUri(nextPageUri); err != nil {
+			return []ContentList{}, err
+		}
+
+		// Followed verbatim: its nextPage parameter is an opaque server-side id.
+		link = nextPageUri
+	}
+
+	return []ContentList{}, catcher.Error("exceeded the content list page limit", nil, map[string]any{
+		"process":      "plugin_com.utmstack.o365",
+		"subscription": subscription,
+		"maxPages":     maxContentListPages,
+	})
+}
+
+func (o *OfficeProcessor) validateNextPageUri(nextPageUri string) error {
+	endpoint, err := url.Parse(o.CloudConfig.ManagementEndpoint)
+	if err != nil {
+		return catcher.Error("cannot parse management endpoint", err, map[string]any{
+			"process": "plugin_com.utmstack.o365",
+		})
+	}
+
+	next, err := url.Parse(nextPageUri)
+	if err != nil {
+		return catcher.Error("cannot parse NextPageUri", err, map[string]any{
+			"process": "plugin_com.utmstack.o365",
+		})
+	}
+
+	if !strings.EqualFold(next.Scheme, endpoint.Scheme) || !strings.EqualFold(next.Host, endpoint.Host) {
+		return catcher.Error("NextPageUri does not match the management endpoint", nil, map[string]any{
+			"process": "plugin_com.utmstack.o365",
+			"host":    next.Host,
+			"scheme":  next.Scheme,
+		})
+	}
+
+	return nil
+}
+
+func (o *OfficeProcessor) getContentListPage(link string, subscription string) ([]ContentList, http.Header, error) {
 	headers := map[string]string{
 		"Content-Type":  "application/json",
 		"Authorization": fmt.Sprintf("%s %s", o.Credentials.TokenType, o.Credentials.AccessToken),
 	}
 
-	// Retry logic for getting content list
 	maxRetries := 3
 	retryDelay := 2 * time.Second
 
 	var respBody []ContentList
+	var respHeaders http.Header
 	var status int
 	var err error
 
 	for retry := 0; retry < maxRetries; retry++ {
-		respBody, status, err = utils.DoReq[[]ContentList](link, nil, http.MethodGet, headers, false)
+		respBody, respHeaders, status, err = doReqWithHeaders[[]ContentList](link, nil, http.MethodGet, headers)
 		if err == nil && status == http.StatusOK {
-			return respBody, nil
+			return respBody, respHeaders, nil
 		}
 
 		_ = catcher.Error("error getting content list, retrying", err, map[string]any{
@@ -455,12 +513,11 @@ func (o *OfficeProcessor) GetContentList(subscription string, startTime time.Tim
 
 		if retry < maxRetries-1 {
 			time.Sleep(retryDelay)
-			// Increase delay for next retry
 			retryDelay *= 2
 		}
 	}
 
-	return []ContentList{}, catcher.Error("all retries failed when getting content list", err, map[string]any{
+	return nil, nil, catcher.Error("all retries failed when getting content list", err, map[string]any{
 		"process":      "plugin_com.utmstack.o365",
 		"subscription": subscription,
 		"status":       status,

--- a/plugins/o365/request.go
+++ b/plugins/o365/request.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+)
+
+var requestClient = &http.Client{Timeout: 60 * time.Second}
+
+// Exists because the go-sdk utils.DoReq helper cannot surface response headers.
+func doReqWithHeaders[T any](link string, body []byte, method string, headers map[string]string) (T, http.Header, int, error) {
+	var result T
+
+	var payload io.Reader
+	if len(body) > 0 {
+		payload = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequest(method, link, payload)
+	if err != nil {
+		return result, nil, 0, err
+	}
+
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+
+	resp, err := requestClient.Do(req)
+	if err != nil {
+		return result, nil, 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return result, resp.Header, resp.StatusCode, err
+	}
+
+	return result, resp.Header, resp.StatusCode, nil
+}

--- a/plugins/o365/request.go
+++ b/plugins/o365/request.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"time"
@@ -34,7 +35,18 @@ func doReqWithHeaders[T any](link string, body []byte, method string, headers ma
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return result, resp.Header, resp.StatusCode, err
+	}
+
+	// Same error shape as utils.DoReq, so a failure carries the API's own code.
+	if resp.StatusCode >= http.StatusBadRequest {
+		return result, resp.Header, resp.StatusCode,
+			fmt.Errorf("error response (status=%d): %s", resp.StatusCode, string(respBody))
+	}
+
+	if err := json.Unmarshal(respBody, &result); err != nil {
 		return result, resp.Header, resp.StatusCode, err
 	}
 

--- a/plugins/o365/state.go
+++ b/plugins/o365/state.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/threatwinds/go-sdk/catcher"
+	"github.com/threatwinds/go-sdk/plugins"
+)
+
+const stateFileName = "o365_state.json"
+
+type persistedState struct {
+	Groups map[string]persistedGroup `json:"groups"`
+}
+
+type persistedGroup struct {
+	GroupName string    `json:"groupName"`
+	WindowEnd time.Time `json:"windowEnd"`
+}
+
+func defaultStatePath() string {
+	return filepath.Join(plugins.WorkDir, "pipeline", stateFileName)
+}
+
+func loadPositions(path string) map[int32]persistedGroup {
+	positions := make(map[int32]persistedGroup)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			_ = catcher.Error("unable to read the collection state, resuming from the default window", err, map[string]any{
+				"process": "plugin_com.utmstack.o365",
+				"file":    path,
+			})
+		}
+		return positions
+	}
+
+	var state persistedState
+	// A corrupt checkpoint degrades to the default seeding instead of stopping collection.
+	if err := json.Unmarshal(data, &state); err != nil {
+		_ = catcher.Error("unable to parse the collection state, resuming from the default window", err, map[string]any{
+			"process": "plugin_com.utmstack.o365",
+			"file":    path,
+		})
+		return positions
+	}
+
+	for key, group := range state.Groups {
+		id, err := strconv.ParseInt(key, 10, 32)
+		if err != nil {
+			continue
+		}
+		positions[int32(id)] = group
+	}
+
+	return positions
+}
+
+func savePositions(path string, positions map[int32]persistedGroup) {
+	state := persistedState{Groups: make(map[string]persistedGroup, len(positions))}
+	for id, group := range positions {
+		state.Groups[strconv.FormatInt(int64(id), 10)] = group
+	}
+
+	data, err := json.Marshal(state)
+	if err != nil {
+		_ = catcher.Error("unable to encode the collection state", err, map[string]any{
+			"process": "plugin_com.utmstack.o365",
+		})
+		return
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		_ = catcher.Error("unable to create the collection state directory", err, map[string]any{
+			"process": "plugin_com.utmstack.o365",
+			"file":    path,
+		})
+		return
+	}
+
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		_ = catcher.Error("unable to write the collection state", err, map[string]any{
+			"process": "plugin_com.utmstack.o365",
+			"file":    path,
+		})
+		return
+	}
+
+	if err := os.Rename(tmp, path); err != nil {
+		_ = catcher.Error("unable to finalize the collection state", err, map[string]any{
+			"process": "plugin_com.utmstack.o365",
+			"file":    path,
+		})
+	}
+}

--- a/plugins/o365/window.go
+++ b/plugins/o365/window.go
@@ -1,0 +1,23 @@
+package main
+
+import "time"
+
+const (
+	// The Management Activity API returns partial results, not an error, beyond 24h; 12h leaves boundary margin.
+	maxCollectionWindow = 12 * time.Hour
+	// Clamp short of the API's 7 day retention: the request is issued seconds after now is captured.
+	maxCollectionLookback = 6 * 24 * time.Hour
+)
+
+func nextWindow(position, now time.Time, size time.Duration) (time.Time, time.Time, bool) {
+	if size <= 0 || !position.Before(now) {
+		return time.Time{}, time.Time{}, false
+	}
+
+	end := position.Add(size)
+	if end.After(now) {
+		end = now
+	}
+
+	return position, end, true
+}


### PR DESCRIPTION
Closes #2435
Closes #2436

## What was broken

**#2436** — The API truncates content-list responses and signals continuation with a
`NextPageUri` response header. The collector read only the first response, so every
content blob past the first page was dropped. No error surfaced, because the first
request succeeded.

**#2435** — The collection window lived in memory and advanced by wall clock every
tick, whether collection succeeded or not. Any restart re-seeded it to five minutes
ago; any transient failure skipped that range forever.

Fixed in that order on purpose: persisting a checkpoint over a truncated enumeration
would record "interval complete" while pages were missing, which is worse than the
original bug.

## What was built

`GetContentList` follows the `NextPageUri` chain to the end, using a local HTTP
helper because `utils.DoReq` cannot return response headers. The URL is validated
against the configured management endpoint's scheme and host before being followed —
the request carries a bearer token — and then used verbatim, since its `nextPage`
parameter is an opaque server id.

Each group owns a collection window position, persisted to disk. Per tick:

load position (or seed at now-5m on first run)
clamp forward if older than 6 days
window = position, min(position + 12h, now)
collect it
    on error   → return; position untouched, next tick retries the same range
    on success → position = window end, persisted

For that to work, errors had to stop being swallowed. `GetLogs` now returns the
events it gathered *together with* an error when any subscription or blob failed,
and `pull` propagates it. `GetContentDetails` also requires HTTP 200 now, matching
`GetContentList`.

### State file

`{WORK_DIR}/pipeline/o365_state.json` — one timestamp per group, written atomically
(temp file + rename) under the same lock that guards the in-memory map:

```json
{"groups":{"3":{"groupName":"test","windowEnd":"2026-09-07T19:19:43.488057286Z"}}}
```
Missing file is a normal first run. A corrupt one is logged and treated as empty,
falling back to the old seeding behaviour rather than stopping collection. A failed
write never aborts a tick.
One timestamp per group is enough because the API filters on when a blob became
available, not when the event happened, so a high-water mark cannot miss
late-arriving events.
Third fix
StartSubscriptions returned nil from inside the retry loop on "already
enabled", which exited the whole function and abandoned the other four content
types. If one failed to start on the very first run, it was never attempted again
and its content stayed unavailable permanently.