### PR TITLE
feature/standardize actionresult o365 azure

### DIFF
--- a/filters/office365/o365.yml
+++ b/filters/office365/o365.yml
@@ -100,7 +100,14 @@ pipeline:
           params:
             key: actionResult
             value: 'failed'
-          where: oneOf("log.ResultStatus", ["Failure", "Failed"])
+          where: oneOf("log.ResultStatus", ["Failure", "Failed", "False"])
+
+      - add:
+          function: 'string'
+          params:
+            key: actionResult
+            value: 'blocked'
+          where: equals("log.ResultStatus", "Blocked")
 
       # Adding geolocation to origin ip
       - dynamic:

--- a/rules/cloud/azure/defense_evasion_event_hub_deletion.yml
+++ b/rules/cloud/azure/defense_evasion_event_hub_deletion.yml
@@ -52,7 +52,7 @@ where: |
   (equalsIgnoreCase("log.category", "Administrative") || contains("log.category", "Activity")) &&
   (equalsIgnoreCase("log.operationName", "MICROSOFT.EVENTHUB/NAMESPACES/EVENTHUBS/DELETE") ||
   contains("log.operationName", "Delete EventHub")) &&
-  (equalsIgnoreCase("log.resultType", "0") || equalsIgnoreCase("actionResult", "SUCCESS"))
+  (equalsIgnoreCase("log.resultType", "0") || equalsIgnoreCase("actionResult", "success"))
 groupBy:
   - adversary.ip
   - adversary.user

--- a/rules/cloud/azure/impact_azure_service_principal_credentials_added.yml
+++ b/rules/cloud/azure/impact_azure_service_principal_credentials_added.yml
@@ -48,7 +48,7 @@ references:
 where: |
   equalsIgnoreCase("log.category", "AuditLogs") &&
   contains("log.operationName", "Add service principal") &&
-  (equals("log.resultType", "0") || equalsIgnoreCase("actionResult", "SUCCESS"))
+  (equals("log.resultType", "0") || equalsIgnoreCase("actionResult", "success"))
 groupBy:
   - adversary.ip
   - adversary.user

--- a/rules/cloud/azure/persistence_azure_pim_user_added_global_admin.yml
+++ b/rules/cloud/azure/persistence_azure_pim_user_added_global_admin.yml
@@ -73,7 +73,7 @@ references:
 
 where: |
   equalsIgnoreCase("log.category", "AuditLogs") &&
-  (equals("log.resultType", "0") || equalsIgnoreCase("actionResult", "SUCCESS")) &&
+  (equals("log.resultType", "0") || equalsIgnoreCase("actionResult", "success")) &&
   (contains("log.operationName", "Add eligible member to role") || contains("log.operationName", "Add member to role")) &&
   (contains("log.properties.targetResources.displayName", "Global Administrator") || contains("log.properties.targetResources.displayName", "Company Administrator"))
 groupBy:

--- a/rules/cloud/azure/persistence_mfa_disabled_for_azure_user.yml
+++ b/rules/cloud/azure/persistence_mfa_disabled_for_azure_user.yml
@@ -78,7 +78,7 @@ references:
 where: |
   equalsIgnoreCase("log.category", "AuditLogs") &&
   equalsIgnoreCase("log.operationName", "Disable Strong Authentication") &&
-  (equals("log.resultType", "0") || equalsIgnoreCase("actionResult", "SUCCESS"))
+  (equals("log.resultType", "0") || equalsIgnoreCase("actionResult", "success"))
 groupBy:
   - target.ip
   - target.user

--- a/rules/office365/app_consent_grants.yml
+++ b/rules/office365/app_consent_grants.yml
@@ -24,7 +24,7 @@ description: |
   5. If malicious, revoke the application consent and remove the app registration
   6. Consider implementing application consent policies to prevent unauthorized app installations
 where: |
-  equals("action", "Consent to application") && equals("actionResult", "Success")
+  equals("action", "Consent to application") && equals("actionResult", "success")
 groupBy:
   - lastEvent.log.appAccessContextClientAppId
   - adversary.user

--- a/rules/office365/audit_log_tampering.yml
+++ b/rules/office365/audit_log_tampering.yml
@@ -28,7 +28,7 @@ where: |
   (equals("log.Workload", "Exchange") && contains("log.ObjectId", "AdminAuditLog")) ||
   (contains("log.Parameters", "UnifiedAuditLogIngestionEnabled") && contains("log.Parameters", "false"))) &&
   exists("origin.user") &&
-  equals("actionResult", "Succeeded")
+  equals("actionResult", "success")
 groupBy:
   - lastEvent.action
   - adversary.user

--- a/rules/office365/azure_ad_integration_events.yml
+++ b/rules/office365/azure_ad_integration_events.yml
@@ -28,9 +28,9 @@ description: |
 where: |
   equals("log.Workload", "AzureActiveDirectory") &&
   (
-    (equals("action", "Add member to role") && equals("actionResult", "Success")) ||
-    (equals("action", "Delete user") && equals("actionResult", "Success")) ||
-    (equals("action", "Add service principal") && equals("actionResult", "Success"))
+    (equals("action", "Add member to role") && equals("actionResult", "success")) ||
+    (equals("action", "Delete user") && equals("actionResult", "success")) ||
+    (equals("action", "Add service principal") && equals("actionResult", "success"))
   )
 afterEvents:
   - indexPattern: v11-log-o365-*

--- a/rules/office365/collection_microsoft_365_new_inbox_rule.yml
+++ b/rules/office365/collection_microsoft_365_new_inbox_rule.yml
@@ -20,7 +20,7 @@ references:
   - "https://attack.mitre.org/techniques/T1114/003/"
   - "https://attack.mitre.org/tactics/TA0009/"
 where: |
-  equals("log.Workload", "Exchange") && equals("action", "New-InboxRule") && oneOf("actionResult", ["Success","Succeeded","PartiallySucceeded","True"])
+  equals("log.Workload", "Exchange") && equals("action", "New-InboxRule") && equals("actionResult", "success")
 groupBy:
   - adversary.ip
   - adversary.user

--- a/rules/office365/compliance_alert_patterns.yml
+++ b/rules/office365/compliance_alert_patterns.yml
@@ -40,7 +40,7 @@ where: |
     equals("action", "Remove-ComplianceRule") ||
     equals("action", "Remove-ComplianceTag")
   ) &&
-  equals("actionResult", "Success")
+  equals("actionResult", "success")
 afterEvents:
   - indexPattern: v11-log-o365-*
     with:

--- a/rules/office365/conditional_access_bypasses.yml
+++ b/rules/office365/conditional_access_bypasses.yml
@@ -26,7 +26,7 @@ description: |
   7. Monitor for additional suspicious activities from the same user or IP
 where: |
   (oneOf("action", ["UserLoggedIn", "UserLoginFailed"]) &&
-   (oneOf("log.ConditionalAccessStatus", ["failure", "notApplied"]) && equals("actionResult", "Succeeded"))) &&
+   (oneOf("log.ConditionalAccessStatus", ["failure", "notApplied"]) && equals("actionResult", "success"))) &&
   exists("origin.user") &&
   exists("origin.ip")
 afterEvents:

--- a/rules/office365/credential_access_microsoft_365_potential_password_spraying_attack.yml
+++ b/rules/office365/credential_access_microsoft_365_potential_password_spraying_attack.yml
@@ -16,7 +16,7 @@ references:
 description: "Credential Access consists of techniques for stealing credentials like account names and passwords. Techniques used to get credentials include keylogging or credential dumping. Using legitimate credentials can give adversaries access to systems, make them harder to detect, and provide the opportunity to create more accounts to help achieve their goals.<br>
   Identifies a high number (25) of failed Microsoft 365 user authentication attempts from a single IP address within 30 minutes, which could be indicative of a password spraying attack. An adversary may attempt a password spraying attack to obtain unauthorized access to user accounts."
 where: |
-  oneOf("log.Workload", ["Exchange", "AzureActiveDirectory"]) && oneOf("action", ["UserLoginFailed", "PasswordLogonInitialAuthUsingPassword"]) && oneOf("actionResult", ["Failed", "False"]) && exists("origin.ip")
+  oneOf("log.Workload", ["Exchange", "AzureActiveDirectory"]) && oneOf("action", ["UserLoginFailed", "PasswordLogonInitialAuthUsingPassword"]) && equals("actionResult", "failed") && exists("origin.ip")
 afterEvents:
   - indexPattern: v11-log-o365-*
     with:

--- a/rules/office365/defense_evasion_microsoft_365_exchange_malware_filter_policy_deletion.yml
+++ b/rules/office365/defense_evasion_microsoft_365_exchange_malware_filter_policy_deletion.yml
@@ -16,7 +16,7 @@ references:
   - "https://attack.mitre.org/techniques/T1562/"
   - "https://attack.mitre.org/tactics/TA0005/"
 where: |
-  equals("log.Workload", "Exchange") && equals("action", "Remove-MalwareFilterPolicy") && oneOf("actionResult", ["Success","PartiallySucceeded","True"])
+  equals("log.Workload", "Exchange") && equals("action", "Remove-MalwareFilterPolicy") && equals("actionResult", "success")
 groupBy:
   - adversary.ip
   - adversary.user

--- a/rules/office365/defense_evasion_microsoft_365_exchange_malware_filter_rule_mod.yml
+++ b/rules/office365/defense_evasion_microsoft_365_exchange_malware_filter_rule_mod.yml
@@ -16,7 +16,7 @@ references:
   - "https://attack.mitre.org/techniques/T1562/"
   - "https://attack.mitre.org/tactics/TA0005/"
 where: |
-  equals("log.Workload", "Exchange") && oneOf("action", ["Remove-MalwareFilterRule","Disable-MalwareFilterRule"]) && oneOf("actionResult", ["Success","PartiallySucceeded","True"])
+  equals("log.Workload", "Exchange") && oneOf("action", ["Remove-MalwareFilterRule","Disable-MalwareFilterRule"]) && equals("actionResult", "success")
 groupBy:
   - adversary.ip
   - adversary.user

--- a/rules/office365/defense_evasion_microsoft_365_exchange_safe_attach_rule_disabled.yml
+++ b/rules/office365/defense_evasion_microsoft_365_exchange_safe_attach_rule_disabled.yml
@@ -18,7 +18,7 @@ references:
   - "https://attack.mitre.org/techniques/T1562/"
   - "https://attack.mitre.org/tactics/TA0005/"
 where: |
-  equals("log.Workload", "Exchange") && equals("action", "Disable-SafeAttachmentRule") && oneOf("actionResult", ["Success","PartiallySucceeded","True"])
+  equals("log.Workload", "Exchange") && equals("action", "Disable-SafeAttachmentRule") && equals("actionResult", "success")
 groupBy:
   - adversary.ip
   - adversary.user

--- a/rules/office365/dlp_policy_violations.yml
+++ b/rules/office365/dlp_policy_violations.yml
@@ -41,7 +41,7 @@ where: |
     equals("log.Workload", "Teams") ||
     equals("log.Workload", "SecurityComplianceCenter")
   ) &&
-  !equals("actionResult", "Failed")
+  !equals("actionResult", "failed")
 groupBy:
   - lastEvent.log.PolicyId
   - lastEvent.log.SensitiveInfoTypeData

--- a/rules/office365/ediscovery_abuse.yml
+++ b/rules/office365/ediscovery_abuse.yml
@@ -28,7 +28,7 @@ description: |
 where: |
   oneOf("action", ["SearchStarted", "SearchExported", "SearchCreated", "CaseAdded", "HoldCreated", "SearchExportDownloaded", "SearchPreviewed", "SearchResultsPurged"]) &&
   exists("origin.user") &&
-  equals("actionResult", "Succeeded")
+  equals("actionResult", "success")
 afterEvents:
   - indexPattern: v11-log-o365-*
     with:

--- a/rules/office365/exchange_admin_changes.yml
+++ b/rules/office365/exchange_admin_changes.yml
@@ -26,7 +26,7 @@ description: |
   7. If unauthorized, immediately review affected configurations and revert if necessary
 where: |
   oneOf("action", ["Set-AdminAuditLogConfig", "Set-TransportRule", "Set-MalwareFilterPolicy", "Set-HostedContentFilterPolicy", "Set-DkimSigningConfig", "Set-OrganizationConfig", "Set-RoleGroup", "Add-RoleGroupMember", "Remove-RoleGroupMember", "New-ManagementRoleAssignment", "Remove-ManagementRoleAssignment"]) && 
-  equals("actionResult", "Success")
+  equals("actionResult", "success")
 afterEvents:
   - indexPattern: v11-log-o365-*
     with:

--- a/rules/office365/exfiltration_microsoft_365_exchange_transport_rule_creation.yml
+++ b/rules/office365/exfiltration_microsoft_365_exchange_transport_rule_creation.yml
@@ -17,7 +17,7 @@ references:
   - "https://attack.mitre.org/techniques/T1537/"
   - "https://attack.mitre.org/tactics/TA0010/"
 where: |
-  equals("log.Workload", "Exchange") && equals("action", "New-TransportRule") && oneOf("actionResult", ["Success","PartiallySucceeded","True"])
+  equals("log.Workload", "Exchange") && equals("action", "New-TransportRule") && equals("actionResult", "success")
 groupBy:
   - adversary.ip
   - adversary.user

--- a/rules/office365/exfiltration_microsoft_365_exchange_transport_rule_mod.yml
+++ b/rules/office365/exfiltration_microsoft_365_exchange_transport_rule_mod.yml
@@ -17,7 +17,7 @@ references:
   - "https://attack.mitre.org/techniques/T1537/"
   - "https://attack.mitre.org/tactics/TA0010/"
 where: |
-  equals("log.Workload", "Exchange") && oneOf("action", ["Remove-TransportRule","Disable-TransportRule"]) && oneOf("actionResult", ["Success","PartiallySucceeded","True"])
+  equals("log.Workload", "Exchange") && oneOf("action", ["Remove-TransportRule","Disable-TransportRule"]) && equals("actionResult", "success")
 groupBy:
   - adversary.ip
   - adversary.user

--- a/rules/office365/external_sharing_violations.yml
+++ b/rules/office365/external_sharing_violations.yml
@@ -36,7 +36,7 @@ where: |
     equals("action", "CompanyLinkCreated") ||
     equals("action", "AddedToSecureLink")
   ) &&
-  equals("actionResult", "Success") &&
+  equals("actionResult", "success") &&
   (
     equals("log.TargetUserOrGroupType", "Guest") ||
     contains("log.SiteUrl", "external") ||

--- a/rules/office365/forms_sway_phishing.yml
+++ b/rules/office365/forms_sway_phishing.yml
@@ -28,7 +28,7 @@ description: |
 where: |
   (oneOf("action", ["FormCreated", "FormUpdated", "FormShared"]) ||
    contains("action", "Sway")) &&
-  equals("actionResult", "Success") &&
+  equals("actionResult", "success") &&
   (contains("log.Parameters", "password") ||
    contains("log.Parameters", "credential") ||
    contains("log.Parameters", "login") ||

--- a/rules/office365/guest_user_invitation_spikes.yml
+++ b/rules/office365/guest_user_invitation_spikes.yml
@@ -32,7 +32,7 @@ where: |
     equals("action", "Add guest to group") ||
     equals("action", "Guest user invite redeemed")
   ) &&
-  equals("actionResult", "Success")
+  equals("actionResult", "success")
 afterEvents:
   - indexPattern: v11-log-o365-*
     with:

--- a/rules/office365/information_barriers_violations.yml
+++ b/rules/office365/information_barriers_violations.yml
@@ -24,7 +24,7 @@ description: |
   5. Provide additional training to users if violations appear to be due to lack of awareness
   6. Consider implementing additional technical controls to prevent future violations
 where: |
-  equals("action", "InformationBarrierPolicyViolation") || (equals("log.PolicyType", "InformationBarrier") && equals("actionResult", "Blocked")) || (equals("log.ViolationType", "InformationBarrier") && equals("action", "CommunicationBlocked"))
+  equals("action", "InformationBarrierPolicyViolation") || (equals("log.PolicyType", "InformationBarrier") && equals("actionResult", "blocked")) || (equals("log.ViolationType", "InformationBarrier") && equals("action", "CommunicationBlocked"))
 afterEvents:
   - indexPattern: v11-log-o365-*
     with:

--- a/rules/office365/initial_access_microsoft_365_exchange_anti_phish_policy_deletion.yml
+++ b/rules/office365/initial_access_microsoft_365_exchange_anti_phish_policy_deletion.yml
@@ -18,7 +18,7 @@ references:
   - "https://attack.mitre.org/techniques/T1566/"
   - "https://attack.mitre.org/tactics/TA0001/"
 where: |
-  equals("log.Workload", "Exchange") && equals("action", "Remove-AntiPhishPolicy") && oneOf("actionResult", ["Success","PartiallySucceeded","True"])
+  equals("log.Workload", "Exchange") && equals("action", "Remove-AntiPhishPolicy") && equals("actionResult", "success")
 groupBy:
   - adversary.ip
   - adversary.user

--- a/rules/office365/initial_access_microsoft_365_exchange_anti_phish_rule_mod.yml
+++ b/rules/office365/initial_access_microsoft_365_exchange_anti_phish_rule_mod.yml
@@ -17,7 +17,7 @@ references:
   - "https://attack.mitre.org/techniques/T1566/"
   - "https://attack.mitre.org/tactics/TA0001/"
 where: |
-  equals("log.Workload", "Exchange") && oneOf("action", ["Remove-AntiPhishRule","Disable-AntiPhishRule"]) && oneOf("actionResult", ["Success","PartiallySucceeded","True"])
+  equals("log.Workload", "Exchange") && oneOf("action", ["Remove-AntiPhishRule","Disable-AntiPhishRule"]) && equals("actionResult", "success")
 groupBy:
   - adversary.ip
   - adversary.user

--- a/rules/office365/initial_access_microsoft_365_exchange_safelinks_disabled.yml
+++ b/rules/office365/initial_access_microsoft_365_exchange_safelinks_disabled.yml
@@ -19,7 +19,7 @@ references:
   - "https://docs.microsoft.com/en-us/microsoft-365/security/office-365-security/atp-safe-links?view=o365-worldwide"
   - "https://attack.mitre.org/techniques/T1566/"
 where: |
-  equals("log.Workload", "Exchange") && equals("action", "Disable-SafeLinksRule") && oneOf("actionResult", ["Success","PartiallySucceeded","True"])
+  equals("log.Workload", "Exchange") && equals("action", "Disable-SafeLinksRule") && equals("actionResult", "success")
 groupBy:
   - adversary.ip
   - adversary.user

--- a/rules/office365/mail_flow_rule_changes.yml
+++ b/rules/office365/mail_flow_rule_changes.yml
@@ -26,7 +26,7 @@ description: |
   7. If unauthorized, disable the malicious rule immediately and investigate the compromised account
 where: |
   oneOf("action", ["New-TransportRule", "Set-TransportRule", "Remove-TransportRule", "Enable-TransportRule", "Disable-TransportRule"]) &&
-  equals("actionResult", "Success")
+  equals("actionResult", "success")
 afterEvents:
   - indexPattern: v11-log-o365-*
     with:

--- a/rules/office365/mail_forwarding_rules.yml
+++ b/rules/office365/mail_forwarding_rules.yml
@@ -26,7 +26,7 @@ description: |
   7. If malicious, disable the forwarding rule and reset user credentials
 where: |
   oneOf("action", ["NewInboxRule", "Set-InboxRule", "UpdateInboxRules"]) && 
-  equals("actionResult", "Success") &&
+  equals("actionResult", "success") &&
   (contains("log.Parameters", "ForwardTo") || contains("log.Parameters", "ForwardAsAttachmentTo") || contains("log.Parameters", "RedirectTo"))
 groupBy:
   - adversary.ip

--- a/rules/office365/mailbox_delegation_abuse.yml
+++ b/rules/office365/mailbox_delegation_abuse.yml
@@ -27,7 +27,7 @@ description: |
   8. Enable mailbox audit logging if not already enabled
 where: |
   oneOf("action", ["Add-MailboxPermission", "Add-RecipientPermission", "Set-Mailbox"]) &&
-  equals("actionResult", "Success") &&
+  equals("actionResult", "success") &&
   (contains("log.Parameters", "FullAccess") ||
    contains("log.Parameters", "SendAs") ||
    contains("log.Parameters", "SendOnBehalf"))

--- a/rules/office365/mailbox_export_pst.yml
+++ b/rules/office365/mailbox_export_pst.yml
@@ -27,7 +27,7 @@ description: |
   8. Implement RBAC to restrict mailbox export permissions
 where: |
   oneOf("action", ["New-MailboxExportRequest", "New-ComplianceSearchAction", "SearchExportDownloaded"]) &&
-  equals("actionResult", "Success")
+  equals("actionResult", "success")
 groupBy:
   - lastEvent.action
   - adversary.user

--- a/rules/office365/multi_geo_data_violations.yml
+++ b/rules/office365/multi_geo_data_violations.yml
@@ -29,7 +29,7 @@ where: |
   (exists("log.SourceFileName") && exists("log.DestinationFileName") && contains("log.SourceRelativeUrl", "geo") && contains("log.DestinationRelativeUrl", "geo")) ||
   (contains("log.Parameters", "DataLocation") || contains("log.Parameters", "PreferredDataLocation"))) &&
   exists("origin.user") &&
-  equals("actionResult", "Succeeded") &&
+  equals("actionResult", "success") &&
   exists("origin.ip")
 afterEvents:
   - indexPattern: v11-log-o365-*

--- a/rules/office365/o365-admin-role-assignment.yml
+++ b/rules/office365/o365-admin-role-assignment.yml
@@ -18,7 +18,7 @@ impact:
   integrity: 3
   availability: 0
 where: equals("log.Workload", "AzureActiveDirectory") && oneOf("action", ["Add member to group.", "Add delegated permission grant.", "Add member to role."]) &&
-      equals("actionResult", "Success")
+      equals("actionResult", "success")
 groupBy:
   - adversary.user
   - lastEvent.log.ObjectId

--- a/rules/office365/oauth_app_anomalies.yml
+++ b/rules/office365/oauth_app_anomalies.yml
@@ -25,7 +25,7 @@ description: |
   - Review other users who may have consented to the same application
   - Implement conditional access policies to restrict high-risk OAuth consents
 where: |
-  equals("action", "Consent to application") && equals("actionResult", "Success") && (contains("log.Scope", "Mail.") || contains("log.Scope", "Files.") || contains("log.Scope", "User.ReadWrite") || contains("log.Scope", ".All"))
+  equals("action", "Consent to application") && equals("actionResult", "success") && (contains("log.Scope", "Mail.") || contains("log.Scope", "Files.") || contains("log.Scope", "User.ReadWrite") || contains("log.Scope", ".All"))
 afterEvents:
   - indexPattern: v11-log-o365-*
     with:

--- a/rules/office365/possible_succesfull_password_guessing_o365.yml
+++ b/rules/office365/possible_succesfull_password_guessing_o365.yml
@@ -21,7 +21,7 @@ references:
   - "https://attack.mitre.org/tactics/TA0006"
   - "https://attack.mitre.org/techniques/T1110/001/"
 where: |
-  oneOf("log.Workload", ["Exchange","AzureActiveDirectory"]) && equals("action", "UserLoginFailed") && oneOf("actionResult", ["Failed","False"]) && exists("origin.user") && exists("log.clientIP")
+  oneOf("log.Workload", ["Exchange","AzureActiveDirectory"]) && equals("action", "UserLoginFailed") && equals("actionResult", "failed") && exists("origin.user") && exists("log.clientIP")
 afterEvents:
     - indexPattern: v11-log-o365-*
       with:

--- a/rules/office365/power_apps_data_leaks.yml
+++ b/rules/office365/power_apps_data_leaks.yml
@@ -27,7 +27,7 @@ description: |
   8. If unauthorized, immediately revoke access and investigate potential data compromise
 where: |
   oneOf("action", ["CreateDataConnection", "UpdateDataConnection", "ExportData", "ImportData"]) &&
-  equals("actionResult", "Success") &&
+  equals("actionResult", "success") &&
   equals("log.Workload", "PowerApps")
 afterEvents:
   - indexPattern: v11-log-o365-*

--- a/rules/office365/power_automate_abuse.yml
+++ b/rules/office365/power_automate_abuse.yml
@@ -27,7 +27,7 @@ description: |
   8. Consider implementing Power Platform DLP policies to prevent future abuse
 where: |
   oneOf("action", ["CreateFlow", "ShareFlow", "CreateConnection"]) &&
-  equals("actionResult", "Success") &&
+  equals("actionResult", "success") &&
   equals("log.Workload", "PowerAutomate")
 afterEvents:
   - indexPattern: v11-log-o365-*

--- a/rules/office365/power_bi_data_export.yml
+++ b/rules/office365/power_bi_data_export.yml
@@ -27,7 +27,7 @@ description: |
   8. Enable row-level security on sensitive datasets
 where: |
   oneOf("action", ["ExportReport", "ExportDataflow", "DownloadReport", "ExportArtifact"]) &&
-  equals("actionResult", "Success")
+  equals("actionResult", "success")
 afterEvents:
   - indexPattern: v11-log-o365-*
     with:

--- a/rules/office365/safe_attachment_violations.yml
+++ b/rules/office365/safe_attachment_violations.yml
@@ -26,7 +26,7 @@ description: |
   7. Consider implementing additional email security controls if gaps are identified
 where: |
   oneOf("action", ["Set-SafeAttachmentPolicy", "Remove-SafeAttachmentPolicy", "Disable-SafeAttachmentRule"]) &&
-  equals("actionResult", "Success")
+  equals("actionResult", "success")
 groupBy:
   - lastEvent.action
   - adversary.user

--- a/rules/office365/safe_links_click_patterns.yml
+++ b/rules/office365/safe_links_click_patterns.yml
@@ -24,7 +24,7 @@ description: |
   5. Implement additional security awareness training for the affected user
   6. Consider blocking the malicious domains at the network level
 where: |
-  equals("action", "ClickedSafeLink") && equals("actionResult", "Blocked") && exists("origin.user")
+  equals("action", "ClickedSafeLink") && equals("actionResult", "blocked") && exists("origin.user")
 afterEvents:
   - indexPattern: v11-log-o365-*
     with:

--- a/rules/office365/service_principal_credential_addition.yml
+++ b/rules/office365/service_principal_credential_addition.yml
@@ -27,7 +27,7 @@ description: |
   8. Implement Azure AD alerts for credential changes to critical applications
 where: |
   oneOf("action", ["Add service principal credentials.", "Update application - Certificates and secrets management"]) &&
-  equals("actionResult", "Success")
+  equals("actionResult", "success")
 groupBy:
   - lastEvent.log.Parameters
   - adversary.user

--- a/rules/office365/sharepoint_permission_escalation.yml
+++ b/rules/office365/sharepoint_permission_escalation.yml
@@ -27,7 +27,7 @@ description: |
   8. Implement SharePoint access governance policies
 where: |
   oneOf("action", ["SiteCollectionAdminAdded", "SiteAdmin"]) &&
-  equals("actionResult", "Success")
+  equals("actionResult", "success")
 groupBy:
   - adversary.user
   - target.user

--- a/rules/office365/teams_external_user_abuse.yml
+++ b/rules/office365/teams_external_user_abuse.yml
@@ -27,7 +27,7 @@ description: |
   8. Enable Safe Links and Safe Attachments for Teams
 where: |
   (equals("action", "MemberAdded") || equals("action", "ChatCreated") || equals("action", "MessageSent")) &&
-  equals("actionResult", "Success") &&
+  equals("actionResult", "success") &&
   contains("log.Parameters", "#EXT#")
 afterEvents:
   - indexPattern: v11-log-o365-*

--- a/rules/office365/threat_intelligence_alerts.yml
+++ b/rules/office365/threat_intelligence_alerts.yml
@@ -28,7 +28,7 @@ description: |
   9. Update security policies and user training based on attack vectors
   10. Report findings to incident response team and document lessons learned
 where: |
-  equals("action", "ThreatIntelligenceAlertTriggered") || (equals("log.AlertType", "ThreatIntelligence") && !equals("actionResult", "Success"))
+  equals("action", "ThreatIntelligenceAlertTriggered") || (equals("log.AlertType", "ThreatIntelligence") && !equals("actionResult", "success"))
 groupBy:
   - adversary.user
   - target.user


### PR DESCRIPTION
## Detailed explanation of the changes

The use of the `actionResult` field in the Office 365 and Azure correlation rules has been standardized.

## Reasoning behind these changes

Different rules were reading the `actionResult` from different fields (inconsistent names or outdated paths), which caused some conditions not to trigger even though the event was clearly the one being evaluated. By unifying the name and source of the `actionResult` field, all Office 365 and Azure rules now consume the same signal, with these benefits:

- Rules behave predictably for the same events.

- The possibility of false negatives due to reading the wrong field is reduced.

## Issue reference

_#2478_