### PR TITLE
fix(filters/o365): derive deviceTime from CreationTime instead of collection time

### DIFF
--- a/filters/office365/o365.yml
+++ b/filters/office365/o365.yml
@@ -1,4 +1,4 @@
-# Microsoft 365 filter, version 1.0.4
+# Microsoft 365 filter, version 1.0.5
 
 # Based on Official documentation
 # See https://learn.microsoft.com/en-us/compliance/assurance/assurance-microsoft-365-audit-log-collection
@@ -11,6 +11,12 @@ pipeline:
     steps:
       - json:
           source: raw
+
+      # Normalized event time.
+      - rename:
+          from:
+            - log.CreationTime
+          to: deviceTime
 
       - rename:  
           from:
@@ -35,7 +41,7 @@ pipeline:
       - rename:  
           from:
             - log.AppAccessContext.IssuedAtTime
-          to: log.deviceTime
+          to: log.appAccessContextIssuedAtTime
 
       - rename:  
           from:


### PR DESCRIPTION
## Summary

Microsoft 365 events were indexed at the time UTMStack retrieved them, not at
the time the audited activity happened. This maps the audit record's
`CreationTime` to the normalized `deviceTime` field so the event carries the
time it actually occurred.

Only `filters/office365/o365.yml` changes. No Go code is touched.

## The problem

The o365 filter never mapped `CreationTime`, which is the time the audited
activity occurred and the one time field present on every Management Activity
API record. With no time promoted to `deviceTime`, the engine fell back to
`@timestamp`, which the plugin sets to `time.Now()` when it enqueues the log
(`plugins/o365/main.go:243`).


